### PR TITLE
fix(codex): use rate-limit-reset-credits API for reset expiry

### DIFF
--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -16,7 +16,7 @@
 
 ### GET /backend-api/wham/usage
 
-Returns rate limit windows, optional credits, and available on-demand rate limit resets.
+Returns rate limit windows and optional credits.
 
 #### Headers
 
@@ -55,7 +55,7 @@ Returns rate limit windows, optional credits, and available on-demand rate limit
     "unlimited": false,
     "balance": 820.6969075                 // remaining credits
   },
-  "rate_limit_reset_credits": {            // on-demand resets (optional)
+  "rate_limit_reset_credits": {            // on-demand resets count only (optional)
     "available_count": 1
   }
 }
@@ -67,10 +67,35 @@ UsagePal floors the remaining credit balance to a whole number and displays its 
 equivalent at `$0.04` per credit. For example, `820.6969075` renders as
 `$32.80 · 820 credits`. The credit balance is unbounded; the API does not provide a maximum.
 
-When available, UsagePal displays the on-demand reset count as the first detail text metric,
-for example `1 available`. Banked reset credits expire after 30 days from the date they are
-granted. UsagePal tracks grants locally in `{pluginDataDir}/grants.json` to compute the next
-expiry time, which appears on hover as a tooltip (e.g. `"Expires in 25d 3h"`).
+### GET /backend-api/wham/rate-limit-reset-credits
+
+Returns banked on-demand rate limit resets, including each credit's expiry time.
+
+#### Headers
+
+Same as `/wham/usage`.
+
+#### Response
+
+```jsonc
+{
+  "available_count": 1,
+  "credits": [
+    {
+      "id": "RateLimitResetCredit_…",
+      "reset_type": "codex_rate_limits",
+      "status": "available",               // or "redeemed"
+      "granted_at": "2026-06-17T00:38:38Z",
+      "expires_at": "2026-07-17T00:38:38Z"
+    }
+  ]
+}
+```
+
+UsagePal displays the available reset count as the first detail text metric, for example
+`1 available`. Expiry times come from each available credit's `expires_at` field and appear
+on hover as a tooltip (e.g. `"Expires in 25d 3h"`). If this endpoint fails, UsagePal falls
+back to the count from `/wham/usage` without an expiry time.
 
 ## Authentication
 

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -5,6 +5,7 @@
   const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
   const REFRESH_URL = "https://auth.openai.com/oauth/token"
   const USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+  const RESET_CREDITS_URL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits"
   const CREDIT_USD_RATE = 0.04
   const REFRESH_AGE_MS = 8 * 24 * 60 * 60 * 1000
   const ACCESS_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000
@@ -306,7 +307,7 @@
     }
   }
 
-  function fetchUsage(ctx, accessToken, accountId) {
+  function chatgptHeaders(accessToken, accountId) {
     const headers = {
       Authorization: "Bearer " + accessToken,
       Accept: "application/json",
@@ -315,12 +316,88 @@
     if (accountId) {
       headers["ChatGPT-Account-Id"] = accountId
     }
+    return headers
+  }
+
+  function fetchUsage(ctx, accessToken, accountId) {
     return ctx.util.request({
       method: "GET",
       url: USAGE_URL,
-      headers,
+      headers: chatgptHeaders(accessToken, accountId),
       timeoutMs: 10000,
     })
+  }
+
+  function fetchRateLimitResetCredits(ctx, accessToken, accountId) {
+    return ctx.util.request({
+      method: "GET",
+      url: RESET_CREDITS_URL,
+      headers: chatgptHeaders(accessToken, accountId),
+      timeoutMs: 10000,
+    })
+  }
+
+  function parseRateLimitResetCredits(data) {
+    if (!data || typeof data !== "object") return null
+
+    const credits = Array.isArray(data.credits) ? data.credits : []
+    const availableCredits = []
+    for (let i = 0; i < credits.length; i++) {
+      const credit = credits[i]
+      if (!credit || typeof credit !== "object") continue
+      const status = typeof credit.status === "string" ? credit.status : "available"
+      if (status !== "available") continue
+      availableCredits.push(credit)
+    }
+
+    const reported = data.available_count == null ? null : readNumber(data.available_count)
+    const availableCount = reported !== null
+      ? Math.max(0, Math.floor(reported))
+      : availableCredits.length
+
+    // Only treat an explicit available_count or a credits list as a valid payload.
+    if (reported === null && !Array.isArray(data.credits)) return null
+
+    const expiryIsos = []
+    for (let i = 0; i < availableCredits.length; i++) {
+      const expiresAt = availableCredits[i].expires_at
+      if (typeof expiresAt === "string" && expiresAt) {
+        expiryIsos.push(expiresAt)
+      }
+    }
+    expiryIsos.sort(function (a, b) {
+      return new Date(a).getTime() - new Date(b).getTime()
+    })
+
+    return { availableCount: availableCount, expiryIsos: expiryIsos }
+  }
+
+  function loadRateLimitResetCredits(ctx, accessToken, accountId, usageData) {
+    try {
+      const resp = fetchRateLimitResetCredits(ctx, accessToken, accountId)
+      if (resp.status >= 200 && resp.status < 300) {
+        const data = ctx.util.tryParseJson(resp.bodyText)
+        const parsed = parseRateLimitResetCredits(data)
+        if (parsed) return parsed
+        ctx.host.log.warn("rate limit reset credits response invalid")
+      } else {
+        ctx.host.log.warn("rate limit reset credits returned status=" + resp.status)
+      }
+    } catch (e) {
+      ctx.host.log.warn("rate limit reset credits request failed: " + String(e))
+    }
+
+    const nestedRaw =
+      usageData &&
+      usageData.rate_limit_reset_credits &&
+      typeof usageData.rate_limit_reset_credits === "object"
+        ? usageData.rate_limit_reset_credits.available_count
+        : null
+    const nested = nestedRaw == null ? null : readNumber(nestedRaw)
+    if (nested !== null && nested >= 0) {
+      return { availableCount: Math.floor(nested), expiryIsos: [] }
+    }
+    return null
   }
 
   function readPercent(value) {
@@ -366,91 +443,6 @@
   // Period durations in milliseconds
   var PERIOD_SESSION_MS = 5 * 60 * 60 * 1000    // 5 hours
   var PERIOD_WEEKLY_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
-  var BANKED_RESET_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
-
-  var GRANTS_FILE = "grants.json"
-
-  function readGrantsFile(ctx) {
-    try {
-      var path = ctx.app.pluginDataDir + "/" + GRANTS_FILE
-      if (!ctx.host.fs.exists(path)) return null
-      var text = ctx.host.fs.readText(path)
-      return JSON.parse(text)
-    } catch (e) {
-      return null
-    }
-  }
-
-  function writeGrantsFile(ctx, data) {
-    try {
-      ctx.host.fs.writeText(
-        ctx.app.pluginDataDir + "/" + GRANTS_FILE,
-        JSON.stringify(data)
-      )
-    } catch (e) {
-      ctx.host.log.warn("failed to persist banked reset grants: " + String(e))
-    }
-  }
-
-  function formatBankedExpiry(nowMs, expiresAtMs) {
-    if (expiresAtMs <= nowMs) return "expired"
-    var totalSec = Math.round((expiresAtMs - nowMs) / 1000)
-    var d = Math.floor(totalSec / 86400)
-    var h = Math.floor((totalSec % 86400) / 3600)
-    var m = Math.floor((totalSec % 3600) / 60)
-    if (d > 0) return "in " + d + "d " + h + "h"
-    if (h > 0) return "in " + h + "h " + m + "m"
-    if (m > 0) return "in " + m + "m"
-    return "soon"
-  }
-
-  function updateBankedResetGrants(ctx, nowSec, availableCount) {
-    var stored = readGrantsFile(ctx) || { grants: [] }
-    var storedGrants = Array.isArray(stored.grants) ? stored.grants : []
-    var nowMs = nowSec * 1000
-
-    // Prune expired grants
-    var unexpired = []
-    for (var i = 0; i < storedGrants.length; i++) {
-      if (typeof storedGrants[i].issuedAt === "number" &&
-          storedGrants[i].issuedAt + BANKED_RESET_LIFETIME_MS > nowMs) {
-        unexpired.push(storedGrants[i])
-      }
-    }
-    storedGrants = unexpired
-
-    var storedCount = storedGrants.length
-    var changed = false
-
-    if (availableCount > storedCount) {
-      // New grants observed — record them
-      var newCount = availableCount - storedCount
-      for (var j = 0; j < newCount; j++) {
-        storedGrants.push({ issuedAt: nowMs })
-      }
-      changed = true
-    } else if (availableCount < storedCount) {
-      // Count decreased — remove oldest (most likely consumed or expired)
-      storedGrants = storedGrants.slice(storedCount - availableCount)
-      changed = true
-    }
-
-    // Collect all expiry timestamps (soonest first)
-    var expiries = []
-    for (var k = 0; k < storedGrants.length; k++) {
-      var expMs = storedGrants[k].issuedAt + BANKED_RESET_LIFETIME_MS
-      if (expMs > nowMs) {
-        expiries.push(expMs)
-      }
-    }
-    expiries.sort(function(a, b) { return a - b })
-
-    if (changed) {
-      writeGrantsFile(ctx, { grants: storedGrants })
-    }
-
-    return expiries
-  }
 
   function queryTokenUsage(ctx) {
     if (!ctx.host.ccusage || typeof ctx.host.ccusage.query !== "function") {
@@ -971,24 +963,19 @@
         }
       }
 
-      const resetCredits =
-        data.rate_limit_reset_credits &&
-        typeof data.rate_limit_reset_credits === "object" &&
-        data.rate_limit_reset_credits.available_count != null
-          ? readNumber(data.rate_limit_reset_credits.available_count)
-          : null
-      if (resetCredits !== null && resetCredits >= 0) {
-        const resetCount = Math.floor(resetCredits)
-        const allExpiryMs = resetCount > 0
-          ? updateBankedResetGrants(ctx, nowSec, resetCount)
-          : []
-        const resetExpiry = allExpiryMs.length > 0
-          ? allExpiryMs.map(function(ms) { return ctx.util.toIso(ms / 1000) })
-          : null
+      const resetCreditsInfo = loadRateLimitResetCredits(
+        ctx,
+        auth.tokens.access_token || accessToken,
+        accountId,
+        data
+      )
+      if (resetCreditsInfo) {
         lines.push(ctx.line.text({
           label: "Rate Limit Resets",
-          value: resetCount + " available",
-          resetExpiry: resetExpiry,
+          value: resetCreditsInfo.availableCount + " available",
+          resetExpiry: resetCreditsInfo.expiryIsos.length > 0
+            ? resetCreditsInfo.expiryIsos
+            : null,
         }))
       }
 

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -730,7 +730,7 @@ describe("codex plugin", () => {
       const plugin = await loadPlugin()
       plugin.probe(ctx)
 
-      expect(ctx.host.http.request).toHaveBeenCalledTimes(1)
+      expect(ctx.host.http.request).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()
     }
@@ -750,7 +750,7 @@ describe("codex plugin", () => {
     const plugin = await loadPlugin()
     plugin.probe(ctx)
 
-    expect(ctx.host.http.request).toHaveBeenCalledTimes(1)
+    expect(ctx.host.http.request).toHaveBeenCalledTimes(2)
   })
 
   it("proactively refreshes a JWT within five minutes of expiry", async () => {
@@ -780,7 +780,7 @@ describe("codex plugin", () => {
       const plugin = await loadPlugin()
       plugin.probe(ctx)
 
-      expect(ctx.host.http.request).toHaveBeenCalledTimes(2)
+      expect(ctx.host.http.request).toHaveBeenCalledTimes(3)
     } finally {
       vi.useRealTimers()
     }
@@ -824,7 +824,7 @@ describe("codex plugin", () => {
       const plugin = await loadPlugin()
       plugin.probe(ctx)
 
-      expect(ctx.host.http.request).toHaveBeenCalledTimes(1)
+      expect(ctx.host.http.request).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()
     }
@@ -1398,13 +1398,29 @@ describe("codex plugin", () => {
       tokens: { access_token: "token" },
       last_refresh: new Date().toISOString(),
     }))
-    ctx.host.http.request.mockReturnValue({
-      status: 200,
-      headers: {},
-      bodyText: JSON.stringify({
-        rate_limit_reset_credits: { available_count: 1 },
-        credits: { balance: 100 },
-      }),
+    const expiresAt = "2026-08-01T12:00:00.000Z"
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("rate-limit-reset-credits")) {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({
+            available_count: 1,
+            credits: [{
+              id: "RateLimitResetCredit_1",
+              status: "available",
+              expires_at: expiresAt,
+            }],
+          }),
+        }
+      }
+      return {
+        status: 200,
+        headers: {},
+        bodyText: JSON.stringify({
+          credits: { balance: 100 },
+        }),
+      }
     })
     ctx.host.ccusage.query.mockReturnValue({
       status: "ok",
@@ -1421,8 +1437,8 @@ describe("codex plugin", () => {
       type: "text",
       label: "Rate Limit Resets",
       value: "1 available",
+      resetExpiry: [expiresAt],
     })
-    expect(result.lines[resetIndex].resetExpiry).toBeDefined()
     expect(resetIndex).toBeGreaterThanOrEqual(0)
     expect(resetIndex).toBe(firstTextIndex)
     expect(creditsIndex).toBe(resetIndex + 1)
@@ -1436,88 +1452,100 @@ describe("codex plugin", () => {
     }))
     const plugin = await loadPlugin()
 
-    ctx.host.http.request.mockReturnValueOnce({
-      status: 200,
-      headers: {},
-      bodyText: JSON.stringify({
-        rate_limit_reset_credits: { available_count: 0 },
-      }),
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("rate-limit-reset-credits")) {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({ available_count: 0, credits: [] }),
+        }
+      }
+      return { status: 200, headers: {}, bodyText: JSON.stringify({}) }
     })
     const zeroResult = plugin.probe(ctx)
     expect(zeroResult.lines.find((line) => line.label === "Rate Limit Resets")?.value)
       .toBe("0 available")
 
-    ctx.host.http.request.mockReturnValueOnce({
-      status: 200,
-      headers: {},
-      bodyText: JSON.stringify({
-        rate_limit_reset_credits: { available_count: null },
-      }),
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("rate-limit-reset-credits")) {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({ available_count: null }),
+        }
+      }
+      return { status: 200, headers: {}, bodyText: JSON.stringify({}) }
     })
     const malformedResult = plugin.probe(ctx)
     expect(malformedResult.lines.find((line) => line.label === "Rate Limit Resets"))
       .toBeUndefined()
   })
 
-  it("writes grants.json when banked reset count increases and includes resetExpiry", async () => {
+  it("uses expires_at from rate-limit-reset-credits for resetExpiry", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
       tokens: { access_token: "token" },
       last_refresh: new Date().toISOString(),
     }))
 
-    const now = 1_700_000_000_000
-    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
-    const issuedAtMs = now
-    const expectedExpiryMs = issuedAtMs + 30 * 24 * 60 * 60 * 1000
-    const expectedExpiryIso = new Date(expectedExpiryMs).toISOString()
-
-    ctx.host.http.request.mockReturnValue({
-      status: 200,
-      headers: {},
-      bodyText: JSON.stringify({
-        rate_limit_reset_credits: { available_count: 2 },
-      }),
+    const sooner = "2026-07-20T00:00:00.000Z"
+    const later = "2026-08-01T00:00:00.000Z"
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("rate-limit-reset-credits")) {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({
+            available_count: 2,
+            credits: [
+              {
+                id: "RateLimitResetCredit_later",
+                status: "available",
+                expires_at: later,
+              },
+              {
+                id: "RateLimitResetCredit_sooner",
+                status: "available",
+                expires_at: sooner,
+              },
+              {
+                id: "RateLimitResetCredit_used",
+                status: "redeemed",
+                expires_at: "2026-07-01T00:00:00.000Z",
+              },
+            ],
+          }),
+        }
+      }
+      return { status: 200, headers: {}, bodyText: JSON.stringify({}) }
     })
     ctx.host.ccusage.query.mockReturnValue({ status: "ok", data: { daily: [] } })
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-
-    expect(ctx.host.fs.writeText).toHaveBeenCalledWith(
-      expect.stringContaining("grants.json"),
-      expect.any(String),
-    )
-
-    // Verify grants.json content
-    const writeCall = ctx.host.fs.writeText.mock.calls.find(([p]) =>
-      String(p).endsWith("grants.json"),
-    )
-    expect(writeCall).toBeTruthy()
-    const grantsData = JSON.parse(writeCall[1])
-    expect(grantsData.grants).toHaveLength(2)
-    expect(grantsData.grants[0].issuedAt).toBe(issuedAtMs)
-    expect(grantsData.grants[1].issuedAt).toBe(issuedAtMs)
-
-    // Verify output line has resetExpiry (array of all expiry ISOs, soonest first)
     const line = result.lines.find((l) => l.label === "Rate Limit Resets")
-    expect(line.resetExpiry).toEqual([expectedExpiryIso, expectedExpiryIso])
-
-    nowSpy.mockRestore()
+    expect(line.value).toBe("2 available")
+    expect(line.resetExpiry).toEqual([sooner, later])
+    expect(ctx.host.fs.writeText.mock.calls.find(([p]) =>
+      String(p).endsWith("grants.json"),
+    )).toBeUndefined()
   })
 
-  it("omits resetExpiry when banked reset count is zero", async () => {
+  it("omits resetExpiry when available count is zero", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
       tokens: { access_token: "token" },
       last_refresh: new Date().toISOString(),
     }))
-    ctx.host.http.request.mockReturnValue({
-      status: 200,
-      headers: {},
-      bodyText: JSON.stringify({
-        rate_limit_reset_credits: { available_count: 0 },
-      }),
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("rate-limit-reset-credits")) {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({ available_count: 0, credits: [] }),
+        }
+      }
+      return { status: 200, headers: {}, bodyText: JSON.stringify({}) }
     })
     ctx.host.ccusage.query.mockReturnValue({ status: "ok", data: { daily: [] } })
 
@@ -1529,47 +1557,31 @@ describe("codex plugin", () => {
     expect(line.resetExpiry).toBeUndefined()
   })
 
-  it("reads previously-written grants and returns next resetExpiry on subsequent probes", async () => {
+  it("falls back to usage available_count without expiry when reset-credits endpoint fails", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
       tokens: { access_token: "token" },
       last_refresh: new Date().toISOString(),
     }))
-
-    // Both grants issued at different times but both still within their 30-day lifetime
-    const now = Date.now()
-    const olderIssuedAtMs = now - 15 * 24 * 60 * 60 * 1000   // 15 days ago
-    const newerIssuedAtMs = now - 5 * 24 * 60 * 60 * 1000    // 5 days ago
-    const olderExpiryMs = olderIssuedAtMs + 30 * 24 * 60 * 60 * 1000 // 15 days from now
-
-    // Pre-populate grants.json in the format the plugin expects: { grants: [...] }
-    const grantsPath = ctx.app.pluginDataDir + "/grants.json"
-    ctx.host.fs.writeText(grantsPath, JSON.stringify({
-      grants: [
-        { issuedAt: olderIssuedAtMs },
-        { issuedAt: newerIssuedAtMs },
-      ],
-    }))
-
-    ctx.host.http.request.mockReturnValue({
-      status: 200,
-      headers: {},
-      bodyText: JSON.stringify({
-        rate_limit_reset_credits: { available_count: 2 },
-      }),
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("rate-limit-reset-credits")) {
+        return { status: 500, headers: {}, bodyText: "error" }
+      }
+      return {
+        status: 200,
+        headers: {},
+        bodyText: JSON.stringify({
+          rate_limit_reset_credits: { available_count: 2 },
+        }),
+      }
     })
     ctx.host.ccusage.query.mockReturnValue({ status: "ok", data: { daily: [] } })
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     const line = result.lines.find((l) => l.label === "Rate Limit Resets")
-
-    // All grant expiries sorted soonest-first
-    const newerExpiryMs = newerIssuedAtMs + 30 * 24 * 60 * 60 * 1000
-    expect(line.resetExpiry).toEqual([
-      new Date(olderExpiryMs).toISOString(),
-      new Date(newerExpiryMs).toISOString(),
-    ])
+    expect(line.value).toBe("2 available")
+    expect(line.resetExpiry).toBeUndefined()
   })
 
   it("omits resetsAt when window lacks reset info", async () => {


### PR DESCRIPTION
## Description

Codex Rate Limit Resets now fetch count and expiry from `GET /backend-api/wham/rate-limit-reset-credits` instead of estimating expiry as grant time + 30 days via local `grants.json`. If the dedicated endpoint fails, the plugin falls back to the usage payload count without an expiry.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [x] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

Ran `npx vitest run plugins/codex/plugin.test.js` (81 passed).

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

Made with [Cursor](https://cursor.com)