### PR TITLE
fix(amp): update Amp to support newest usage format

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ UsagePal lives in your menu bar and shows you how much of your AI coding subscri
 
 ## Supported Providers
 
-- [**Amp**](docs/providers/amp.md) / free tier, bonus, credits
+- [**Amp**](docs/providers/amp.md) / daily free usage, credits
 - [**Antigravity**](docs/providers/antigravity.md) / all models
 - [**Claude**](docs/providers/claude.md) / session, weekly, extra usage, local token usage (ccusage)
 - [**ClinePass**](docs/providers/cline-pass.md) / Session, weekly, monthly limits, balance, usage trend

--- a/docs/providers/amp.md
+++ b/docs/providers/amp.md
@@ -5,7 +5,7 @@
 - **Protocol:** JSON-RPC (`POST /api/internal`)
 - **URL:** `https://ampcode.com/api/internal`
 - **Auth:** API key from Amp CLI (`~/.local/share/amp/secrets.json`)
-- **Tier:** Free (daily replenishing quota) and/or individual credits
+- **Tier:** Free (daily quota) and/or individual credits
 
 ## Authentication
 
@@ -40,7 +40,7 @@ The response contains a `displayText` string whose contents vary by user tier:
 **Free tier + credits:**
 ```
 Signed in as <user>
-Amp Free: $<remaining>/$<total> remaining (replenishes +$<rate>/hour) [optional: +N% bonus for N more days] - https://ampcode.com/settings#amp-free
+Amp Free: <percent>% remaining today (resets daily) - https://ampcode.com/settings#amp-free
 Individual credits: $<credits> remaining - https://ampcode.com/settings
 ```
 
@@ -51,15 +51,13 @@ Individual credits: $<credits> remaining - https://ampcode.com/settings
 ```
 
 The plugin parses the display text with regex to extract:
-- **Balance:** `$remaining/$total remaining` → dollar amounts (only if Amp Free enabled)
-- **Rate:** `replenishes +$rate/hour` → replenishment speed (only if Amp Free enabled)
-- **Bonus:** `[+N% bonus for N more days]` → optional promotional bonus 
+- **Free quota:** `<percent>% remaining today` → daily percentage remaining
 - **Credits:** `Individual credits: $N remaining` → paid credits balance
 
 ### Usage Calculation (Free tier only)
 
-- **Used:** `total - remaining` (clamped to 0 minimum)
-- **Reset time:** `used / hourlyRate` hours from now (null if nothing used or rate is zero)
+- **Used:** `100 - percent remaining` (clamped between 0% and 100%)
+- **Reset time:** Not supplied by the API; the response only states that it resets daily
 - **Period:** 24 hours (fixed)
 
 ## Plan Detection
@@ -73,13 +71,13 @@ The plugin parses the display text with regex to extract:
 
 | Line       | Scope    | Condition                   | Description                            |
 |------------|----------|-----------------------------|----------------------------------------|
-| Free       | overview | Amp Free enabled            | Dollar amount consumed as progress bar |
-| Bonus      | detail   | Amp Free + active promotion | Bonus percentage and duration          |
+| Free       | overview | Amp Free enabled            | Daily usage consumed as a percentage progress bar |
 | Credits    | overview | Credits > $0, or credits-only accounts | Individual credits balance      |
 
 Progress line includes:
-- `resetsAt` — ISO timestamp of estimated full replenishment (null if nothing used or rate is zero)
 - `periodDurationMs` — 24 hours for pace tracking
+
+The API does not provide an exact reset time, so the progress line does not include `resetsAt`.
 
 ## Errors
 

--- a/plugins/amp/plugin.js
+++ b/plugins/amp/plugin.js
@@ -39,12 +39,19 @@
     if (!text || typeof text !== "string") return null
 
     var result = {
+      remainingPct: null,
       remaining: null,
       total: null,
       hourlyRate: 0,
       bonusPct: null,
       bonusDays: null,
       credits: null,
+    }
+
+    var percentMatch = text.match(/Amp Free: ([0-9]+(?:\.[0-9]+)?)% remaining today/)
+    if (percentMatch) {
+      var remainingPct = Number(percentMatch[1])
+      if (Number.isFinite(remainingPct)) result.remainingPct = remainingPct
     }
 
     var balanceMatch = text.match(/\$([0-9][0-9,]*(?:\.[0-9]+)?)\/\$([0-9][0-9,]*(?:\.[0-9]+)?) remaining/)
@@ -79,7 +86,7 @@
       if (Number.isFinite(credits)) result.credits = credits
     }
 
-    if (result.total === null && result.credits === null) return null
+    if (result.remainingPct === null && result.total === null && result.credits === null) return null
 
     return result
   }
@@ -122,17 +129,25 @@
     var balance = parseBalanceText(json.result.displayText)
     if (!balance) {
       if (/Amp Free/.test(json.result.displayText)) {
-        ctx.host.log.error("failed to parse display text: " + json.result.displayText)
+        ctx.host.log.error("failed to parse Amp Free display text")
         throw "Could not parse usage data."
       }
-      ctx.host.log.warn("no balance data found, assuming credits-only: " + json.result.displayText)
-      balance = { remaining: null, total: null, hourlyRate: 0, bonusPct: null, bonusDays: null, credits: 0 }
+      ctx.host.log.warn("no balance data found, assuming credits-only")
+      balance = { remainingPct: null, remaining: null, total: null, hourlyRate: 0, bonusPct: null, bonusDays: null, credits: 0 }
     }
 
     var lines = []
     var plan = "Free"
 
-    if (balance.total !== null) {
+    if (balance.remainingPct !== null) {
+      lines.push(ctx.line.progress({
+        label: "Free",
+        used: Math.min(100, Math.max(0, 100 - balance.remainingPct)),
+        limit: 100,
+        format: { kind: "percent" },
+        periodDurationMs: 24 * 3600 * 1000,
+      }))
+    } else if (balance.total !== null) {
       var used = Math.max(0, balance.total - balance.remaining)
       var total = balance.total
 
@@ -159,9 +174,10 @@
       }
     }
 
-    if (balance.credits !== null && balance.total === null) plan = "Credits"
+    var hasFreeTier = balance.remainingPct !== null || balance.total !== null
+    if (balance.credits !== null && !hasFreeTier) plan = "Credits"
 
-    if (balance.credits !== null && (balance.credits > 0 || balance.total === null)) {
+    if (balance.credits !== null && (balance.credits > 0 || !hasFreeTier)) {
       lines.push(ctx.line.text({
         label: "Credits",
         value: "$" + balance.credits.toFixed(2),

--- a/plugins/amp/plugin.test.js
+++ b/plugins/amp/plugin.test.js
@@ -163,6 +163,28 @@ describe("amp plugin", () => {
 
   // --- Balance parsing ---
 
+  it("parses the current daily percentage response", async () => {
+    var ctx = makeCtx()
+    writeSecrets(ctx)
+    var text = "Signed in as user@test.com (testuser)\n"
+      + "Amp Free: 48% remaining today (resets daily) - https://ampcode.com/settings#amp-free\n"
+      + "Individual credits: $0 remaining - https://ampcode.com/settings"
+    ctx.host.http.request.mockReturnValue(balanceResponse(text))
+    var plugin = await loadPlugin()
+    var result = plugin.probe(ctx)
+    expect(result.plan).toBe("Free")
+    expect(result.lines).toHaveLength(1)
+    expect(result.lines[0]).toMatchObject({
+      type: "progress",
+      label: "Free",
+      used: 52,
+      limit: 100,
+      format: { kind: "percent" },
+      periodDurationMs: 24 * 3600 * 1000,
+    })
+    expect(result.lines[0].resetsAt).toBeUndefined()
+  })
+
   it("parses standard balance text", async () => {
     var ctx = makeCtx()
     writeSecrets(ctx)

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -106,6 +106,7 @@ const SENSITIVE_JSON_KEYS: &[&str] = &[
     "account_display_name",
     "accountDisplayName",
     "displayName",
+    "displayText",
     "payment_id",
     "paymentId",
     "subscription_id",
@@ -3871,6 +3872,18 @@ mod tests {
             "plan displayName should also be redacted, got: {}",
             redacted
         );
+    }
+
+    #[test]
+    fn redact_body_redacts_display_text() {
+        let body = r#"{"ok":true,"result":{"displayText":"Signed in as person@example.com (nickname)\nAmp Free: 48% remaining today"}}"#;
+        let redacted = redact_body(body);
+        assert!(
+            !redacted.contains("person@example.com") && !redacted.contains("nickname"),
+            "displayText should be redacted, got: {}",
+            redacted
+        );
+        assert!(redacted.contains("\"displayText\": \"Sign...oday\""));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Amp's API changed how it reports free-tier usage. It used to return dollar amounts ($remaining/$total), but now returns a daily percentage. 

Fix the parser to handle the new format and also closes a redaction gap where user emails were leaking into debug logs.

## Related Issue

None, just straight PR

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Screenshots

Before:
<img width="400" height="281" alt="image" src="https://github.com/user-attachments/assets/7f6c264d-d073-4b43-ba58-8a8cdbacc78f" />

After:
<img width="400" height="325" alt="image" src="https://github.com/user-attachments/assets/d4614320-66e1-4355-953a-0bbc3c5aef61" />

## Checklist

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification
