### PR TITLE
feat: What's New window after update

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the app windows (tray panel and onboarding setup)",
-  "windows": ["main", "setup"],
+  "description": "Capability for the app windows (tray panel, onboarding setup, and what's-new)",
+  "windows": ["main", "setup", "whats-new"],
   "permissions": [
     "core:default",
     "core:tray:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -817,6 +817,8 @@ pub fn run() {
             send_pace_notification,
             onboarding::finish_onboarding,
             onboarding::reset_onboarding,
+            whats_new::get_release_notes,
+            whats_new::dismiss_whats_new,
             beta_updater::check_beta_update,
             beta_updater::download_beta_update,
             beta_updater::install_beta_update,
@@ -947,6 +949,8 @@ pub fn run() {
 
             onboarding::show_setup_window_if_needed(app.handle())?;
 
+            whats_new::show_whats_new_window_if_needed(app.handle())?;
+
             // Register global shortcut from stored settings
             #[cfg(desktop)]
             {
@@ -1016,6 +1020,8 @@ fn export_bindings() {
             send_pace_notification,
             onboarding::finish_onboarding,
             onboarding::reset_onboarding,
+            whats_new::get_release_notes,
+            whats_new::dismiss_whats_new,
             beta_updater::check_beta_update,
             beta_updater::download_beta_update,
             beta_updater::install_beta_update,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod panel;
 mod keylight;
 mod plugin_engine;
 mod tray;
+mod whats_new;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;

--- a/src-tauri/src/onboarding.rs
+++ b/src-tauri/src/onboarding.rs
@@ -1,4 +1,4 @@
-use tauri::{Emitter, Manager};
+use tauri::Emitter;
 use tauri_plugin_store::StoreExt;
 
 pub const SETTINGS_STORE: &str = "settings.json";
@@ -22,29 +22,12 @@ pub fn show_setup_window_if_needed(app_handle: &tauri::AppHandle) -> tauri::Resu
         return Ok(());
     }
 
-    if let Some(window) = app_handle.get_webview_window("setup") {
-        window.show()?;
-        window.set_focus()?;
-        return Ok(());
-    }
-
-    tauri::WebviewWindowBuilder::new(
+    crate::panel::create_chromeless_window(
         app_handle,
         "setup",
-        tauri::WebviewUrl::App("index.html#/setup".into()),
-    )
-    .title("UsagePal Setup")
-    .inner_size(560.0, 620.0)
-    .min_inner_size(560.0, 620.0)
-    .resizable(false)
-    // Chromeless: the web header carries the drag region; Escape dismisses.
-    // Transparent so the CSS rounded corners are the real window shape.
-    .decorations(false)
-    .transparent(true)
-    .center()
-    .visible(true)
-    .focused(true)
-    .build()?;
+        "index.html#/setup",
+        "UsagePal Setup",
+    )?;
 
     Ok(())
 }
@@ -74,16 +57,11 @@ pub fn finish_onboarding(app_handle: tauri::AppHandle, open_settings: bool) -> R
         log::error!("failed to emit plugins:changed: {error}");
     }
 
-    if let Some(window) = app_handle.get_webview_window("setup") {
-        window
-            .close()
-            .map_err(|error| format!("failed to close setup window: {error}"))?;
-    }
-
-    crate::panel::show_panel_from_tray(
+    crate::panel::close_window_and_show_panel(
         &app_handle,
+        "setup",
         if open_settings { "settings" } else { "home" },
-    );
+    )?;
 
     Ok(())
 }

--- a/src-tauri/src/onboarding.rs
+++ b/src-tauri/src/onboarding.rs
@@ -50,6 +50,10 @@ fn save_onboarding_completion(app_handle: &tauri::AppHandle) -> Result<(), Strin
 #[specta::specta]
 pub fn finish_onboarding(app_handle: tauri::AppHandle, open_settings: bool) -> Result<(), String> {
     save_onboarding_completion(&app_handle)?;
+    crate::whats_new::save_last_seen_version(
+        &app_handle,
+        &app_handle.package_info().version.to_string(),
+    )?;
 
     // The onboarding window saved the provider selection just before this
     // call; tell the running panel to reload plugin settings from the store.
@@ -74,6 +78,7 @@ pub fn reset_onboarding(app_handle: tauri::AppHandle) -> Result<(), String> {
         .map_err(|error| format!("failed to open settings store: {error}"))?;
     store.delete(ONBOARDING_COMPLETED_KEY);
     store.delete(ONBOARDING_COMPLETED_AT_KEY);
+    store.delete(crate::whats_new::LAST_SEEN_VERSION_KEY);
     store
         .save()
         .map_err(|error| format!("failed to save onboarding reset: {error}"))

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -135,6 +135,56 @@ pub fn show_panel_from_tray(app_handle: &AppHandle, view: &str) {
     }
 }
 
+/// Build (or show) a 560×620 chromeless, transparent, centered window — the shape
+/// shared by the onboarding setup window and the what's-new window. If a window
+/// with the given label already exists, just show and focus it.
+pub fn create_chromeless_window(
+    app_handle: &AppHandle,
+    label: &str,
+    url: &str,
+    title: &str,
+) -> tauri::Result<()> {
+    if let Some(window) = app_handle.get_webview_window(label) {
+        window.show()?;
+        window.set_focus()?;
+        return Ok(());
+    }
+
+    tauri::WebviewWindowBuilder::new(
+        app_handle,
+        label,
+        tauri::WebviewUrl::App(url.into()),
+    )
+    .title(title)
+    .inner_size(560.0, 620.0)
+    .min_inner_size(560.0, 620.0)
+    .resizable(false)
+    .decorations(false)
+    .transparent(true)
+    .center()
+    .visible(true)
+    .focused(true)
+    .build()?;
+
+    Ok(())
+}
+
+/// Close a window by label, then show the tray panel at the given view.
+/// Used by both `finish_onboarding` and `dismiss_whats_new`.
+pub fn close_window_and_show_panel(
+    app_handle: &AppHandle,
+    label: &str,
+    view: &str,
+) -> Result<(), String> {
+    if let Some(window) = app_handle.get_webview_window(label) {
+        window
+            .close()
+            .map_err(|error| format!("failed to close {label} window: {error}"))?;
+    }
+    show_panel_from_tray(app_handle, view);
+    Ok(())
+}
+
 pub fn toggle_panel_at_tray_rect(
     app_handle: &AppHandle,
     icon_position: Position,

--- a/src-tauri/src/whats_new.rs
+++ b/src-tauri/src/whats_new.rs
@@ -140,6 +140,26 @@ pub fn parse_release_notes(
     selected
 }
 
+/// Pure decision function for whether the what's-new window should open.
+/// - Onboarding not complete → false (onboarding window handles it).
+/// - Onboarding complete, no last seen version → false (first time or
+///   existing user upgrading to the feature-introducing version).
+/// - Onboarding complete, last seen == current → false (same version relaunch).
+/// - Onboarding complete, last seen != current → true.
+pub fn should_show_whats_new(
+    onboarding_done: bool,
+    last_seen: Option<&str>,
+    current: &str,
+) -> bool {
+    if !onboarding_done {
+        return false;
+    }
+    match last_seen {
+        None => false,
+        Some(seen) => seen != current,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,5 +367,27 @@ Previous stable.
         assert_eq!(notes.len(), 2);
         assert_eq!(notes[0].version, "0.7.35-beta.2");
         assert_eq!(notes[1].version, "0.7.35-beta.1");
+    }
+
+    #[test]
+    fn should_show_whats_new_onboarding_not_done() {
+        assert!(!should_show_whats_new(false, None, "0.7.35"));
+        assert!(!should_show_whats_new(false, Some("0.7.34"), "0.7.35"));
+    }
+
+    #[test]
+    fn should_show_whats_new_last_seen_absent() {
+        // Existing users upgrading to the feature-introducing version — no popup.
+        assert!(!should_show_whats_new(true, None, "0.7.35"));
+    }
+
+    #[test]
+    fn should_show_whats_new_same_version_relaunch() {
+        assert!(!should_show_whats_new(true, Some("0.7.35"), "0.7.35"));
+    }
+
+    #[test]
+    fn should_show_whats_new_different_version() {
+        assert!(should_show_whats_new(true, Some("0.7.34"), "0.7.35"));
     }
 }

--- a/src-tauri/src/whats_new.rs
+++ b/src-tauri/src/whats_new.rs
@@ -5,6 +5,8 @@
 
 use serde::Serialize;
 use specta::Type;
+use tauri::AppHandle;
+use tauri_plugin_store::StoreExt;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Type)]
 pub struct ReleaseNotesSection {
@@ -138,6 +140,96 @@ pub fn parse_release_notes(
     }
 
     selected
+}
+
+pub(crate) fn save_last_seen_version(app_handle: &AppHandle, version: &str) -> Result<(), String> {
+    let store = app_handle
+        .store(crate::onboarding::SETTINGS_STORE)
+        .map_err(|error| format!("failed to open settings store: {error}"))?;
+    store.set(LAST_SEEN_VERSION_KEY, serde_json::json!(version));
+    store
+        .save()
+        .map_err(|error| format!("failed to save lastSeenVersion: {error}"))
+}
+
+/// On startup, show the what's-new window if the user has onboarded and the
+/// persisted `lastSeenVersion` differs from the running version. If onboarding
+/// is done but `lastSeenVersion` is absent (existing user upgrading to the
+/// feature-introducing version), set it silently and skip the popup.
+pub fn show_whats_new_window_if_needed(app_handle: &AppHandle) -> tauri::Result<()> {
+    let onboarding_done = crate::onboarding::is_onboarding_completed(app_handle);
+    let last_seen = app_handle
+        .store(crate::onboarding::SETTINGS_STORE)
+        .ok()
+        .and_then(|store| store.get(LAST_SEEN_VERSION_KEY))
+        .and_then(|value| value.as_str().map(|s| s.to_string()));
+    let current = app_handle.package_info().version.to_string();
+
+    if !should_show_whats_new(onboarding_done, last_seen.as_deref(), &current) {
+        // Existing user upgrading to the feature-introducing version: record
+        // the current version silently so the popup starts from the *next* update.
+        if onboarding_done && last_seen.is_none() {
+            if let Err(error) = save_last_seen_version(app_handle, &current) {
+                log::error!("failed to seed lastSeenVersion: {error}");
+            }
+        }
+        return Ok(());
+    }
+
+    // Verify there are notes to show before opening the window.
+    let notes = parse_release_notes(
+        include_str!("../../CHANGELOG.md"),
+        last_seen.as_deref(),
+        &current,
+    );
+    if notes.is_empty() {
+        log::warn!(
+            "no release notes found for v{} (since {:?}) — skipping what's-new window",
+            current,
+            last_seen
+        );
+        if let Err(error) = save_last_seen_version(app_handle, &current) {
+            log::error!("failed to save lastSeenVersion after empty notes: {error}");
+        }
+        return Ok(());
+    }
+
+    crate::panel::create_chromeless_window(
+        app_handle,
+        "whats-new",
+        "index.html#/whats-new",
+        "What's New in UsagePal",
+    )?;
+
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_release_notes(app_handle: AppHandle) -> Result<Vec<ReleaseNotes>, String> {
+    let last_seen = app_handle
+        .store(crate::onboarding::SETTINGS_STORE)
+        .ok()
+        .and_then(|store| store.get(LAST_SEEN_VERSION_KEY))
+        .and_then(|value| value.as_str().map(|s| s.to_string()));
+    let current = app_handle.package_info().version.to_string();
+
+    Ok(parse_release_notes(
+        include_str!("../../CHANGELOG.md"),
+        last_seen.as_deref(),
+        &current,
+    ))
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn dismiss_whats_new(app_handle: AppHandle) -> Result<(), String> {
+    let current = app_handle.package_info().version.to_string();
+    save_last_seen_version(&app_handle, &current)?;
+
+    crate::panel::close_window_and_show_panel(&app_handle, "whats-new", "home")?;
+
+    Ok(())
 }
 
 /// Pure decision function for whether the what's-new window should open.

--- a/src-tauri/src/whats_new.rs
+++ b/src-tauri/src/whats_new.rs
@@ -1,0 +1,351 @@
+//! Release-notes extraction for the "What's New" window. The changelog is embedded
+//! at compile time via `include_str!` and parsed by `parse_release_notes` into typed
+//! blocks. The window shows when the persisted `lastSeenVersion` differs from the
+//! running version; dismissal saves the current version and opens the tray panel.
+
+use serde::Serialize;
+use specta::Type;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Type)]
+pub struct ReleaseNotesSection {
+    pub title: String,
+    pub items: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Type)]
+pub struct ReleaseNotes {
+    pub version: String,
+    pub summary: String,
+    pub sections: Vec<ReleaseNotesSection>,
+}
+
+pub const LAST_SEEN_VERSION_KEY: &str = "lastSeenVersion";
+
+/// Parse all version blocks from the changelog, in file order (newest-first).
+fn parse_all_versions(changelog: &str) -> Vec<ReleaseNotes> {
+    let mut versions: Vec<ReleaseNotes> = Vec::new();
+    let mut current_block: Option<ReleaseNotes> = None;
+    let mut current_section: Option<ReleaseNotesSection> = None;
+
+    for line in changelog.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with("## v") {
+            // Finalize the previous section and block.
+            if let Some(section) = current_section.take() {
+                if let Some(block) = &mut current_block {
+                    block.sections.push(section);
+                }
+            }
+            if let Some(block) = current_block.take() {
+                versions.push(block);
+            }
+
+            let version = trimmed
+                .strip_prefix("## v")
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            current_block = Some(ReleaseNotes {
+                version,
+                summary: String::new(),
+                sections: Vec::new(),
+            });
+            current_section = None;
+            continue;
+        }
+
+        let Some(block) = &mut current_block else { continue };
+
+        if trimmed.starts_with("### ") {
+            if let Some(section) = current_section.take() {
+                block.sections.push(section);
+            }
+            let title = trimmed
+                .strip_prefix("### ")
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            // Skip the "### Changelog" section (Full Changelog links).
+            current_section = if title == "Changelog" {
+                None
+            } else {
+                Some(ReleaseNotesSection {
+                    title,
+                    items: Vec::new(),
+                })
+            };
+        } else if trimmed.starts_with("- ") {
+            if let Some(section) = &mut current_section {
+                let item = trimmed
+                    .strip_prefix("- ")
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                section.items.push(item);
+            }
+        } else if !trimmed.is_empty() && trimmed != "---" {
+            // The first non-empty, non-separator line before any section is the summary.
+            if block.summary.is_empty() && current_section.is_none() {
+                if !trimmed.starts_with("**Full Changelog**") {
+                    block.summary = trimmed.to_string();
+                }
+            }
+        }
+    }
+
+    // Finalize the last section and block.
+    if let Some(section) = current_section.take() {
+        if let Some(block) = &mut current_block {
+            block.sections.push(section);
+        }
+    }
+    if let Some(block) = current_block {
+        versions.push(block);
+    }
+
+    versions
+}
+
+/// Extract release notes for versions strictly newer than `since` up to and
+/// including `current`. The changelog is newest-first, so the result preserves
+/// that order. If `since` is not found, returns only `current`'s block. If
+/// `current` is not found, returns empty.
+///
+/// Beta filtering: if `current` is a stable version (no `-beta` suffix), beta
+/// entries are excluded. If `current` is a prerelease, all entries are included.
+pub fn parse_release_notes(
+    changelog: &str,
+    since: Option<&str>,
+    current: &str,
+) -> Vec<ReleaseNotes> {
+    let all = parse_all_versions(changelog);
+
+    let Some(current_idx) = all.iter().position(|r| r.version == current) else {
+        return Vec::new();
+    };
+
+    let end = match since.and_then(|s| all.iter().position(|r| r.version == s)) {
+        Some(since_idx) => since_idx,
+        None => current_idx + 1,
+    };
+
+    let mut selected: Vec<ReleaseNotes> = all[current_idx..end].to_vec();
+
+    let current_is_beta = current.contains("-beta");
+    if !current_is_beta {
+        selected.retain(|r| !r.version.contains("-beta"));
+    }
+
+    selected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_CHANGELOG: &str = "\
+# Changelog
+
+## v0.7.35
+
+Stable release for feature X.
+
+### New Features
+- Feature X by @author
+- Feature Y by @author
+
+### Bug Fixes
+- Fix Z by @author
+
+---
+
+### Changelog
+
+**Full Changelog**: [v0.7.34...v0.7.35](https://example.com)
+
+## v0.7.34
+
+Stable release for the models graph.
+
+### New Features
+- Models graph by @author
+
+### Improvements
+- Polish by @author
+
+---
+
+### Changelog
+
+**Full Changelog**: [v0.7.33...v0.7.34](https://example.com)
+
+## v0.7.33
+
+Minor fixes.
+
+### Bug Fixes
+- Small fix by @author
+
+---
+
+### Changelog
+
+**Full Changelog**: [v0.7.32...v0.7.33](https://example.com)
+";
+
+    #[test]
+    fn parse_single_version_range() {
+        let notes = parse_release_notes(SAMPLE_CHANGELOG, Some("0.7.34"), "0.7.35");
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].version, "0.7.35");
+        assert_eq!(notes[0].summary, "Stable release for feature X.");
+        assert_eq!(notes[0].sections.len(), 2);
+        assert_eq!(notes[0].sections[0].title, "New Features");
+        assert_eq!(notes[0].sections[0].items, vec!["Feature X by @author", "Feature Y by @author"]);
+        assert_eq!(notes[0].sections[1].title, "Bug Fixes");
+        assert_eq!(notes[0].sections[1].items, vec!["Fix Z by @author"]);
+    }
+
+    #[test]
+    fn parse_multi_version_skip_updater_range() {
+        let notes = parse_release_notes(SAMPLE_CHANGELOG, Some("0.7.33"), "0.7.35");
+        assert_eq!(notes.len(), 2);
+        assert_eq!(notes[0].version, "0.7.35");
+        assert_eq!(notes[1].version, "0.7.34");
+    }
+
+    #[test]
+    fn parse_excludes_changelog_section() {
+        let notes = parse_release_notes(SAMPLE_CHANGELOG, Some("0.7.34"), "0.7.35");
+        let section_titles: Vec<&str> = notes[0].sections.iter().map(|s| s.title.as_str()).collect();
+        assert!(!section_titles.contains(&"Changelog"));
+    }
+
+    #[test]
+    fn parse_since_not_found_returns_current_only() {
+        let notes = parse_release_notes(SAMPLE_CHANGELOG, Some("0.7.30"), "0.7.35");
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].version, "0.7.35");
+    }
+
+    #[test]
+    fn parse_current_not_found_returns_empty() {
+        let notes = parse_release_notes(SAMPLE_CHANGELOG, Some("0.7.34"), "0.9.99");
+        assert!(notes.is_empty());
+    }
+
+    #[test]
+    fn parse_beta_filtering_stable_current_excludes_betas() {
+        let beta_changelog = "\
+# Changelog
+
+## v0.7.35
+
+Stable release.
+
+### New Features
+- Stable feature by @author
+
+---
+
+### Changelog
+
+**Full Changelog**: [v0.7.34...v0.7.35](https://example.com)
+
+## v0.7.35-beta.2
+
+Beta follow-up.
+
+### New Features
+- Beta feature by @author
+
+---
+
+### Changelog
+
+**Full Changelog**: [v0.7.35-beta.1...v0.7.35-beta.2](https://example.com)
+
+## v0.7.35-beta.1
+
+Beta release.
+
+### New Features
+- Beta feature by @author
+
+---
+
+### Changelog
+
+**Full Changelog**: [v0.7.34...v0.7.35-beta.1](https://example.com)
+
+## v0.7.34
+
+Previous stable.
+
+### Bug Fixes
+- Fix by @author
+
+---
+
+### Changelog
+
+**Full Changelog**: [v0.7.33...v0.7.34](https://example.com)
+";
+        // Current is stable 0.7.35, since is 0.7.34 → should exclude beta entries.
+        let notes = parse_release_notes(beta_changelog, Some("0.7.34"), "0.7.35");
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].version, "0.7.35");
+    }
+
+    #[test]
+    fn parse_beta_filtering_beta_current_includes_betas() {
+        let beta_changelog = "\
+# Changelog
+
+## v0.7.35-beta.2
+
+Beta follow-up.
+
+### New Features
+- Beta feature by @author
+
+---
+
+### Changelog
+
+**Full Changelog**: [v0.7.35-beta.1...v0.7.35-beta.2](https://example.com)
+
+## v0.7.35-beta.1
+
+Beta release.
+
+### New Features
+- Beta feature by @author
+
+---
+
+### Changelog
+
+**Full Changelog**: [v0.7.34...v0.7.35-beta.1](https://example.com)
+
+## v0.7.34
+
+Previous stable.
+
+### Bug Fixes
+- Fix by @author
+
+---
+
+### Changelog
+
+**Full Changelog**: [v0.7.33...v0.7.34](https://example.com)
+";
+        // Current is beta 0.7.35-beta.2, since is 0.7.34 → should include beta entries.
+        let notes = parse_release_notes(beta_changelog, Some("0.7.34"), "0.7.35-beta.2");
+        assert_eq!(notes.len(), 2);
+        assert_eq!(notes[0].version, "0.7.35-beta.2");
+        assert_eq!(notes[1].version, "0.7.35-beta.1");
+    }
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -455,6 +455,25 @@ describe("App", () => {
     expect(screen.queryByText("Alpha")).not.toBeInTheDocument()
   })
 
+  it("renders what's-new app on whats-new route", async () => {
+    window.location.hash = "#/whats-new"
+    state.isTauriMock.mockReturnValue(true)
+    state.invokeMock.mockResolvedValue([
+      {
+        version: "0.7.35",
+        summary: "Test release.",
+        sections: [{ title: "New Features", items: ["Test feature"] }],
+      },
+    ])
+
+    render(<App />)
+
+    expect(await screen.findByRole("heading", { name: "What's New" })).toBeInTheDocument()
+    expect(await screen.findByRole("heading", { name: "v0.7.35" })).toBeInTheDocument()
+    expect(screen.getByText("Test feature")).toBeInTheDocument()
+    expect(screen.queryByText("Alpha")).not.toBeInTheDocument()
+  })
+
   it("renders normal app outside setup route", async () => {
     window.location.hash = "#/settings"
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,11 @@
 import { MainApp } from "@/components/app/main-app"
 import { OnboardingApp } from "@/components/onboarding/onboarding-app"
+import { WhatsNewApp } from "@/components/whats-new/whats-new-app"
 
 function App() {
-  if (window.location.hash === "#/setup") return <OnboardingApp />
+  const hash = window.location.hash
+  if (hash === "#/setup") return <OnboardingApp />
+  if (hash === "#/whats-new") return <WhatsNewApp />
   return <MainApp />
 }
 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -42,6 +42,8 @@ export const commands = {
 	sendPaceNotification: (title: string, body: string) => typedError<null, string>(__TAURI_INVOKE("send_pace_notification", { title, body })),
 	finishOnboarding: (openSettings: boolean) => typedError<null, string>(__TAURI_INVOKE("finish_onboarding", { openSettings })),
 	resetOnboarding: () => typedError<null, string>(__TAURI_INVOKE("reset_onboarding")),
+	getReleaseNotes: () => typedError<ReleaseNotes[], string>(__TAURI_INVOKE("get_release_notes")),
+	dismissWhatsNew: () => typedError<null, string>(__TAURI_INVOKE("dismiss_whats_new")),
 	checkBetaUpdate: () => typedError<{
 	version: string,
 } | null, string>(__TAURI_INVOKE("check_beta_update")),
@@ -166,6 +168,17 @@ export type ProbeResult = {
 };
 
 export type ProgressFormat = { kind: "percent" } | { kind: "dollars" } | { kind: "count"; suffix: string };
+
+export type ReleaseNotes = {
+	version: string,
+	summary: string,
+	sections: ReleaseNotesSection[],
+};
+
+export type ReleaseNotesSection = {
+	title: string,
+	items: string[],
+};
 
 export type TrayRectInput = {
 	x: number | null,

--- a/src/components/chromeless-window-shell.tsx
+++ b/src/components/chromeless-window-shell.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react"
+import { Logo } from "@/components/logo"
+
+type ChromelessWindowShellProps = {
+  /** Optional right-aligned header content (e.g. onboarding step pips). */
+  headerRight?: ReactNode
+  children: ReactNode
+}
+
+/**
+ * The outer chrome shared by the onboarding setup window and the what's-new
+ * window: a rounded transparent container (the visible window shape), a
+ * drag-region header with the logo, and a padded body area.
+ */
+export function ChromelessWindowShell({ headerRight, children }: ChromelessWindowShellProps) {
+  return (
+    <main className="flex h-screen flex-col overflow-hidden rounded-xl border bg-card text-foreground">
+      <section className="flex h-full min-h-0 flex-col">
+        <div
+          data-tauri-drag-region
+          className="flex shrink-0 items-center justify-between border-b px-6 py-4"
+        >
+          <div className="pointer-events-none flex items-center gap-3 text-lg font-semibold">
+            <Logo className="size-9 text-foreground" aria-hidden />
+            UsagePal
+          </div>
+          {headerRight && <div className="pointer-events-none">{headerRight}</div>}
+        </div>
+        <div className="min-h-0 flex-1 px-6 py-5 sm:px-8">{children}</div>
+      </section>
+    </main>
+  )
+}

--- a/src/components/onboarding/onboarding-app.tsx
+++ b/src/components/onboarding/onboarding-app.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft } from "lucide-react"
 
 import { syncAutostart } from "@/lib/autostart"
 
-import { Logo } from "@/components/logo"
+import { ChromelessWindowShell } from "@/components/chromeless-window-shell"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { PACE_MILESTONES } from "@/lib/pace-notifications"
@@ -116,67 +116,60 @@ function OnboardingApp() {
   }, [])
 
   return (
-    // The window itself is transparent; this rounded container is its shape.
-    <main className="flex h-screen flex-col overflow-hidden rounded-xl border bg-card text-foreground">
-      <section className="flex h-full min-h-0 flex-col">
-        {/* data-tauri-drag-region makes the header the window's drag handle. */}
-        <div data-tauri-drag-region className="flex shrink-0 items-center justify-between border-b px-6 py-4">
-          <div className="pointer-events-none flex items-center gap-3 text-lg font-semibold">
-            <Logo className="size-9 text-foreground" aria-hidden />
-            UsagePal
-          </div>
-          <div className="pointer-events-none flex w-28 gap-1.5" aria-label={`Step ${stepIndex(step) + 1} of ${steps.length}`}>
-            {steps.map((item) => (
-              <span
-                key={item}
-                className={cn(
-                  "h-1.5 flex-1 rounded-full bg-border transition-colors duration-500",
-                  stepIndex(item) <= stepIndex(step) && "bg-primary"
-                )}
-              />
-            ))}
-          </div>
+    <ChromelessWindowShell
+      headerRight={
+        <div
+          className="flex w-28 gap-1.5"
+          aria-label={`Step ${stepIndex(step) + 1} of ${steps.length}`}
+        >
+          {steps.map((item) => (
+            <span
+              key={item}
+              className={cn(
+                "h-1.5 flex-1 rounded-full bg-border transition-colors duration-500",
+                stepIndex(item) <= stepIndex(step) && "bg-primary"
+              )}
+            />
+          ))}
         </div>
-
-        <div className="min-h-0 flex-1 px-6 py-5 sm:px-8">
-          <div
-            key={step}
-            className={cn(
-              "h-full animate-in fade-in duration-300",
-              direction === "forward" ? "slide-in-from-right-8" : "slide-in-from-left-8"
-            )}
-          >
-            {step === "welcome" && (
-              <WelcomeStep onContinue={next} onSkip={() => finish(false)} skipBusy={busyAction === "finish"} />
-            )}
-            {step === "tour" && <TourStep onContinue={next} backButton={backButton} />}
-            {step === "notifications" && (
-              <NotificationsStep
-                onEnable={enableNotifications}
-                onSkip={next}
-                busy={busyAction === "notifications"}
-                backButton={backButton}
-              />
-            )}
-            {step === "login" && (
-              <LoginStep
-                onContinue={applyStartOnLogin}
-                busy={busyAction === "login"}
-                backButton={backButton}
-              />
-            )}
-            {step === "done" && (
-              <DoneStep
-                alertsEnabled={alertsEnabled}
-                startOnLogin={startOnLogin}
-                onFinish={finish}
-                busy={busyAction !== null}
-              />
-            )}
-          </div>
-        </div>
-      </section>
-    </main>
+      }
+    >
+      <div
+        key={step}
+        className={cn(
+          "h-full animate-in fade-in duration-300",
+          direction === "forward" ? "slide-in-from-right-8" : "slide-in-from-left-8"
+        )}
+      >
+        {step === "welcome" && (
+          <WelcomeStep onContinue={next} onSkip={() => finish(false)} skipBusy={busyAction === "finish"} />
+        )}
+        {step === "tour" && <TourStep onContinue={next} backButton={backButton} />}
+        {step === "notifications" && (
+          <NotificationsStep
+            onEnable={enableNotifications}
+            onSkip={next}
+            busy={busyAction === "notifications"}
+            backButton={backButton}
+          />
+        )}
+        {step === "login" && (
+          <LoginStep
+            onContinue={applyStartOnLogin}
+            busy={busyAction === "login"}
+            backButton={backButton}
+          />
+        )}
+        {step === "done" && (
+          <DoneStep
+            alertsEnabled={alertsEnabled}
+            startOnLogin={startOnLogin}
+            onFinish={finish}
+            busy={busyAction !== null}
+          />
+        )}
+      </div>
+    </ChromelessWindowShell>
   )
 }
 

--- a/src/components/whats-new/whats-new-app.test.tsx
+++ b/src/components/whats-new/whats-new-app.test.tsx
@@ -51,10 +51,11 @@ describe("WhatsNewApp", () => {
 
     expect(await screen.findByRole("heading", { name: "v0.7.35" })).toBeInTheDocument()
     expect(screen.getByText("Stable release for feature X.")).toBeInTheDocument()
-    expect(screen.getAllByRole("heading", { name: "New Features" })).toHaveLength(2)
+    // Category badges (spans, not headings) — one "New Features" per version.
+    expect(screen.getAllByText("New Features")).toHaveLength(2)
     expect(screen.getByText("Feature X by @author")).toBeInTheDocument()
     expect(screen.getByText("Feature Y by @author")).toBeInTheDocument()
-    expect(screen.getByRole("heading", { name: "Bug Fixes" })).toBeInTheDocument()
+    expect(screen.getByText("Bug Fixes")).toBeInTheDocument()
     // Second version is also rendered.
     expect(screen.getByRole("heading", { name: "v0.7.34" })).toBeInTheDocument()
     expect(screen.getByText("Stable release for the models graph.")).toBeInTheDocument()

--- a/src/components/whats-new/whats-new-app.test.tsx
+++ b/src/components/whats-new/whats-new-app.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const state = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  isTauriMock: vi.fn(() => true),
+}))
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: state.invokeMock,
+  isTauri: state.isTauriMock,
+}))
+
+vi.mock("@/components/ui/tooltip", () => import("@/test/tooltip-mock"))
+
+import { WhatsNewApp } from "@/components/whats-new/whats-new-app"
+
+const SAMPLE_NOTES = [
+  {
+    version: "0.7.35",
+    summary: "Stable release for feature X.",
+    sections: [
+      { title: "New Features", items: ["Feature X by @author", "Feature Y by @author"] },
+      { title: "Bug Fixes", items: ["Fix Z by @author"] },
+    ],
+  },
+  {
+    version: "0.7.34",
+    summary: "Stable release for the models graph.",
+    sections: [
+      { title: "New Features", items: ["Models graph by @author"] },
+      { title: "Improvements", items: ["Polish by @author"] },
+    ],
+  },
+]
+
+describe("WhatsNewApp", () => {
+  beforeEach(() => {
+    state.invokeMock.mockReset()
+    state.isTauriMock.mockReturnValue(true)
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders release notes from get_release_notes", async () => {
+    state.invokeMock.mockResolvedValue(SAMPLE_NOTES)
+
+    render(<WhatsNewApp />)
+
+    expect(await screen.findByRole("heading", { name: "v0.7.35" })).toBeInTheDocument()
+    expect(screen.getByText("Stable release for feature X.")).toBeInTheDocument()
+    expect(screen.getAllByRole("heading", { name: "New Features" })).toHaveLength(2)
+    expect(screen.getByText("Feature X by @author")).toBeInTheDocument()
+    expect(screen.getByText("Feature Y by @author")).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Bug Fixes" })).toBeInTheDocument()
+    // Second version is also rendered.
+    expect(screen.getByRole("heading", { name: "v0.7.34" })).toBeInTheDocument()
+    expect(screen.getByText("Stable release for the models graph.")).toBeInTheDocument()
+  })
+
+  it("renders multiple versions in the scrollable list", async () => {
+    state.invokeMock.mockResolvedValue(SAMPLE_NOTES)
+
+    render(<WhatsNewApp />)
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "v0.7.35" })).toBeInTheDocument()
+    )
+    expect(screen.getByRole("heading", { name: "v0.7.34" })).toBeInTheDocument()
+  })
+
+  it('calls dismiss_whats_new when "Open UsagePal" is clicked', async () => {
+    state.invokeMock.mockResolvedValue(SAMPLE_NOTES)
+
+    render(<WhatsNewApp />)
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "v0.7.35" })).toBeInTheDocument()
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Open UsagePal" }))
+
+    await waitFor(() =>
+      expect(state.invokeMock).toHaveBeenCalledWith("dismiss_whats_new")
+    )
+  })
+
+  it("calls dismiss_whats_new when Escape is pressed", async () => {
+    state.invokeMock.mockResolvedValue(SAMPLE_NOTES)
+
+    render(<WhatsNewApp />)
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "v0.7.35" })).toBeInTheDocument()
+    )
+
+    fireEvent.keyDown(document, { key: "Escape" })
+
+    await waitFor(() =>
+      expect(state.invokeMock).toHaveBeenCalledWith("dismiss_whats_new")
+    )
+  })
+
+  it("renders empty state when no notes are available", async () => {
+    state.invokeMock.mockResolvedValue([])
+
+    render(<WhatsNewApp />)
+
+    expect(await screen.findByText("No release notes available.")).toBeInTheDocument()
+  })
+})

--- a/src/components/whats-new/whats-new-app.tsx
+++ b/src/components/whats-new/whats-new-app.tsx
@@ -3,8 +3,26 @@ import { invoke, isTauri } from "@tauri-apps/api/core"
 import { LoaderCircle } from "lucide-react"
 import type { ReleaseNotes } from "@/bindings"
 import { ChromelessWindowShell } from "@/components/chromeless-window-shell"
-import { StepShell } from "@/components/onboarding/step-shell"
+import { Separator } from "@/components/ui/separator"
 import { Button } from "@/components/ui/button"
+
+/** Tinted badge style per category. Falls back to muted for unknown labels. */
+const CATEGORY_STYLES: Record<string, string> = {
+  "New Features": "bg-green-500/10 text-green-500",
+  "Bug Fixes": "bg-red-500/10 text-red-500",
+  Improvements: "bg-yellow-500/10 text-yellow-500",
+}
+
+function CategoryBadge({ title }: { title: string }) {
+  const style = CATEGORY_STYLES[title] ?? "bg-muted text-muted-foreground"
+  return (
+    <span
+      className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-semibold tracking-wide ${style}`}
+    >
+      {title}
+    </span>
+  )
+}
 
 function WhatsNewApp() {
   const [notes, setNotes] = useState<ReleaseNotes[] | null>(null)
@@ -48,53 +66,85 @@ function WhatsNewApp() {
 
   return (
     <ChromelessWindowShell>
-      <StepShell
-        title="What's New"
-        actions={
-          <Button size="sm" onClick={dismiss}>
-            Open UsagePal
-          </Button>
-        }
-      >
-        {notes === null ? (
-          <div className="flex h-full items-center justify-center">
-            <LoaderCircle
-              className="size-6 animate-spin text-muted-foreground"
-              aria-hidden
-            />
-          </div>
-        ) : notes.length === 0 ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            No release notes available.
-          </div>
-        ) : (
-          <div className="space-y-6">
-            {notes.map((release) => (
-              <div key={release.version} className="space-y-2">
-                <h2 className="text-lg font-semibold">v{release.version}</h2>
-                {release.summary && (
-                  <p className="text-sm text-muted-foreground">{release.summary}</p>
-                )}
-                {release.sections.map((section) => (
-                  <div key={section.title} className="space-y-1">
-                    <h3 className="text-sm font-medium">{section.title}</h3>
-                    <ul className="space-y-1 text-sm text-muted-foreground">
-                      {section.items.map((item, i) => (
-                        <li key={i} className="flex gap-2">
-                          <span className="text-primary" aria-hidden>
-                            ·
-                          </span>
-                          <span>{item}</span>
-                        </li>
+      <div className="flex h-full min-h-0 flex-col">
+        {/* Title */}
+        <div className="mx-auto w-full max-w-md shrink-0 space-y-1.5 animate-in fade-in slide-in-from-bottom-2 duration-300">
+          <h1 className="text-2xl font-semibold tracking-tight">What's New</h1>
+        </div>
+
+        {/* Scrollable release notes */}
+        <div
+          className="min-h-0 flex-1 overflow-y-auto py-5 animate-in fade-in duration-300"
+          style={{ animationDelay: "120ms", animationFillMode: "both" }}
+        >
+          <div className="mx-auto w-full max-w-md">
+            {notes === null ? (
+              <div className="flex h-full items-center justify-center">
+                <LoaderCircle
+                  className="size-6 animate-spin text-muted-foreground"
+                  aria-hidden
+                />
+              </div>
+            ) : notes.length === 0 ? (
+              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                No release notes available.
+              </div>
+            ) : (
+              <div className="space-y-5">
+                {notes.map((release, releaseIdx) => (
+                  <div key={release.version} className="space-y-3">
+                    {releaseIdx > 0 && <Separator />}
+
+                    {/* Version header + summary */}
+                    <div className="space-y-1">
+                      <h2 className="text-base font-semibold">
+                        v{release.version}
+                      </h2>
+                      {release.summary && (
+                        <p className="text-sm leading-5 text-muted-foreground">
+                          {release.summary}
+                        </p>
+                      )}
+                    </div>
+
+                    {/* Category sections */}
+                    <div className="space-y-3">
+                      {release.sections.map((section) => (
+                        <div key={section.title} className="space-y-1.5">
+                          <CategoryBadge title={section.title} />
+                          <ul className="space-y-1 text-sm leading-5 text-muted-foreground">
+                            {section.items.map((item, i) => (
+                              <li key={i} className="flex gap-2">
+                                <span
+                                  className="mt-1.5 size-1 shrink-0 rounded-full bg-foreground/30"
+                                  aria-hidden
+                                />
+                                <span>{item}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
                       ))}
-                    </ul>
+                    </div>
                   </div>
                 ))}
               </div>
-            ))}
+            )}
           </div>
-        )}
-      </StepShell>
+        </div>
+
+        {/* Footer */}
+        <div
+          className="shrink-0 border-t pt-3 animate-in fade-in duration-300"
+          style={{ animationDelay: "240ms", animationFillMode: "both" }}
+        >
+          <div className="flex items-center justify-end gap-3">
+            <Button size="sm" onClick={dismiss}>
+              Open UsagePal
+            </Button>
+          </div>
+        </div>
+      </div>
     </ChromelessWindowShell>
   )
 }

--- a/src/components/whats-new/whats-new-app.tsx
+++ b/src/components/whats-new/whats-new-app.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react"
+import { invoke, isTauri } from "@tauri-apps/api/core"
+import { LoaderCircle } from "lucide-react"
+import type { ReleaseNotes } from "@/bindings"
+import { ChromelessWindowShell } from "@/components/chromeless-window-shell"
+import { StepShell } from "@/components/onboarding/step-shell"
+import { Button } from "@/components/ui/button"
+
+function WhatsNewApp() {
+  const [notes, setNotes] = useState<ReleaseNotes[] | null>(null)
+
+  useEffect(() => {
+    if (!isTauri()) {
+      setNotes([])
+      return
+    }
+    let cancelled = false
+    invoke<ReleaseNotes[]>("get_release_notes")
+      .then((result) => {
+        if (!cancelled) setNotes(result)
+      })
+      .catch((error) => {
+        console.error("Failed to load release notes:", error)
+        if (!cancelled) setNotes([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  async function dismiss() {
+    try {
+      if (isTauri()) await invoke("dismiss_whats_new")
+    } catch (error) {
+      console.error("Failed to dismiss what's new:", error)
+    }
+  }
+
+  // Escape dismisses, matching the onboarding window pattern.
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") void dismiss()
+    }
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <ChromelessWindowShell>
+      <StepShell
+        title="What's New"
+        actions={
+          <Button size="sm" onClick={dismiss}>
+            Open UsagePal
+          </Button>
+        }
+      >
+        {notes === null ? (
+          <div className="flex h-full items-center justify-center">
+            <LoaderCircle
+              className="size-6 animate-spin text-muted-foreground"
+              aria-hidden
+            />
+          </div>
+        ) : notes.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            No release notes available.
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {notes.map((release) => (
+              <div key={release.version} className="space-y-2">
+                <h2 className="text-lg font-semibold">v{release.version}</h2>
+                {release.summary && (
+                  <p className="text-sm text-muted-foreground">{release.summary}</p>
+                )}
+                {release.sections.map((section) => (
+                  <div key={section.title} className="space-y-1">
+                    <h3 className="text-sm font-medium">{section.title}</h3>
+                    <ul className="space-y-1 text-sm text-muted-foreground">
+                      {section.items.map((item, i) => (
+                        <li key={i} className="flex gap-2">
+                          <span className="text-primary" aria-hidden>
+                            ·
+                          </span>
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+      </StepShell>
+    </ChromelessWindowShell>
+  )
+}
+
+export { WhatsNewApp }


### PR DESCRIPTION
## Summary

After the app updates to a new version, a chromeless "What's New" window opens showing release notes parsed from `CHANGELOG.md`. An "Open UsagePal" button (or Escape) dismisses the window and opens the tray panel.

- **Rust:** New `whats_new.rs` with a changelog parser (`parse_release_notes`), a pure decision function (`should_show_whats_new`), and two IPC commands (`get_release_notes`, `dismiss_whats_new`). A `lastSeenVersion` key in `settings.json` tracks the last version the user saw. Onboarding completion and reset now set/clear it.
- **Shared helpers:** Extracted `create_chromeless_window` and `close_window_and_show_panel` from onboarding into `panel.rs` so both windows share the same chromeless-window shape. Extracted `ChromelessWindowShell` on the frontend for the same reason.
- **Frontend:** New `WhatsNewApp` component with color-coded category badges (green for New Features, red for Bug Fixes, yellow for Improvements), version separators, and a loading/empty state. Routed at `#/whats-new`.

## Test plan

- [x] `cargo test` — 158 passed (7 parser tests, 4 decision-function tests, export_bindings, existing tests)
- [x] `npx vitest run` — whats-new component (5 tests), App routing (84 tests), onboarding (18 tests) all pass
- [x] `npx tsc --noEmit` — no type errors
- [x] Manual smoke test — ran `bun run tauri dev` with `lastSeenVersion` set to `0.7.33`; window opened showing v0.7.34 notes, dismissed, did not reopen on relaunch

## Notes

- Pre-existing failures: `src/hooks/app/use-settings-bootstrap.test.ts` has 9 failures on `main` already (missing `DEFAULT_OVERVIEW_SPEND_STRIP_ENABLED` mock export). Not caused by this PR.
- Visual screenshots: verified manually in dev mode; the window renders correctly with category badges and version separators.