### PR TITLE
v0.7.35-beta.2 — usage-bar interaction polish + start-on-login fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.7.35-beta.2
+
+Interaction polish on the usage bars, plus a fix for launch-at-login registering the wrong binary.
+
+### Bug Fixes
+- Start on login no longer registers a dev build's throwaway binary — only the installed app manages the login item, so it launches reliably after a reboot by @Halloweedev
+
+### Improvements
+- Click the "% used" / "% left" text under a usage bar to flip between them (persisted), matching the reset-timer toggle beside it by @Halloweedev
+- Hover the grey pace marker inside a usage bar to see how far through the period you are — "Expected pace — N% of the period has elapsed" by @Halloweedev
+- The "running hot" flame is dropped once a limit is reached; the full bar already says it, so the flame no longer lingers past 100% by @Halloweedev
+
+---
+
 ## v0.7.35-beta.1
 
 Native token & pricing engine. Claude and Codex usage is now computed inside the app — no Node or Bun runtime, no package download — and one shared price source drives every provider. This corrects four pricing details, each named below; some historical figures shift as a result.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "usagepal",
   "private": true,
-  "version": "0.7.35-beta.1",
+  "version": "0.7.35-beta.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6543,7 +6543,7 @@ dependencies = [
 
 [[package]]
 name = "usagepal"
-version = "0.7.35-beta.1"
+version = "0.7.35-beta.2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usagepal"
-version = "0.7.35-beta.1"
+version = "0.7.35-beta.2"
 description = "UsagePal is an open source AI subscription limit tracker (a fork of OpenUsage)"
 authors = ["Nicolas Demanez"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "UsagePal",
-  "version": "0.7.35-beta.1",
+  "version": "0.7.35-beta.2",
   "identifier": "com.halloweed.usagepal",
   "build": {
     "beforeDevCommand": "bun run bundle:plugins && bun run dev",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -409,6 +409,7 @@ describe("App", () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllEnvs()
     window.location.hash = ""
     delete (HTMLElement.prototype as unknown as Record<string, unknown>).scrollHeight
   })
@@ -1020,6 +1021,7 @@ describe("App", () => {
   })
 
   it("applies start on login state on startup in tauri", async () => {
+    vi.stubEnv("DEV", false) // production build: the installed app owns the login item
     state.isTauriMock.mockReturnValue(true)
     state.loadStartOnLoginMock.mockResolvedValueOnce(true)
     state.autostartIsEnabledMock.mockResolvedValueOnce(false)
@@ -1048,6 +1050,7 @@ describe("App", () => {
   })
 
   it("logs when applying start on login setting fails on startup", async () => {
+    vi.stubEnv("DEV", false) // production build: the installed app owns the login item
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     state.isTauriMock.mockReturnValue(true)
     state.loadStartOnLoginMock.mockResolvedValueOnce(true)
@@ -1062,6 +1065,7 @@ describe("App", () => {
   })
 
   it("logs when updating start on login fails from settings", async () => {
+    vi.stubEnv("DEV", false) // production build: the installed app owns the login item
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     state.isTauriMock.mockReturnValue(true)
     state.loadStartOnLoginMock.mockResolvedValueOnce(false)

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -33,6 +33,7 @@ export type AppContentActionProps = {
   onAutoUpdateIntervalChange: (value: AutoUpdateIntervalMinutes) => void
   onThemeModeChange: (mode: ThemeMode) => void
   onDisplayModeChange: (mode: DisplayMode) => void
+  onUsageValueToggle: () => void
   onResetTimerDisplayModeChange: (mode: ResetTimerDisplayMode) => void
   onResetTimerDisplayModeToggle: () => void
   onTimeFormatModeChange: (mode: TimeFormatMode) => void
@@ -59,6 +60,7 @@ export function AppContent({
   onAutoUpdateIntervalChange,
   onThemeModeChange,
   onDisplayModeChange,
+  onUsageValueToggle,
   onResetTimerDisplayModeChange,
   onResetTimerDisplayModeToggle,
   onTimeFormatModeChange,
@@ -122,6 +124,7 @@ export function AppContent({
         timeFormatMode={timeFormatMode}
         overviewSpendStripEnabled={overviewSpendStripEnabled}
         onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
+        onUsageValueToggle={onUsageValueToggle}
       />
     )
   }
@@ -181,6 +184,7 @@ export function AppContent({
       resetTimerDisplayMode={resetTimerDisplayMode}
       timeFormatMode={timeFormatMode}
       onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
+      onUsageValueToggle={onUsageValueToggle}
     />
   )
 }

--- a/src/components/app/main-app.tsx
+++ b/src/components/app/main-app.tsx
@@ -177,6 +177,7 @@ export function MainApp() {
   const {
     handleThemeModeChange,
     handleDisplayModeChange,
+    handleDisplayModeToggle,
     handleResetTimerDisplayModeChange,
     handleResetTimerDisplayModeToggle,
     handleTimeFormatModeChange,
@@ -189,6 +190,7 @@ export function MainApp() {
     menubarIconStyle,
     multiTrayProviderCount,
     setThemeMode,
+    displayMode,
     setDisplayMode,
     resetTimerDisplayMode,
     setResetTimerDisplayMode,
@@ -311,6 +313,7 @@ export function MainApp() {
         onBetaUpdatesEnabledChange: handleBetaUpdatesEnabledChange,
         onThemeModeChange: handleThemeModeChange,
         onDisplayModeChange: handleDisplayModeChange,
+        onUsageValueToggle: handleDisplayModeToggle,
         onResetTimerDisplayModeChange: handleResetTimerDisplayModeChange,
         onResetTimerDisplayModeToggle: handleResetTimerDisplayModeToggle,
         onTimeFormatModeChange: handleTimeFormatModeChange,

--- a/src/components/onboarding/onboarding-app.test.tsx
+++ b/src/components/onboarding/onboarding-app.test.tsx
@@ -76,6 +76,7 @@ async function goToDone() {
 describe("OnboardingApp", () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllEnvs()
   })
 
   beforeEach(() => {
@@ -214,6 +215,7 @@ describe("OnboardingApp", () => {
   })
 
   it("applies start on login when left on", async () => {
+    vi.stubEnv("DEV", false) // production build: the installed app registers autostart
     render(<OnboardingApp />)
     await goToLogin()
 
@@ -247,6 +249,7 @@ describe("OnboardingApp", () => {
   })
 
   it("logs and advances when autostart fails", async () => {
+    vi.stubEnv("DEV", false) // production build: the installed app registers autostart
     const error = new Error("autostart failed")
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
     state.enableMock.mockRejectedValueOnce(error)

--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -649,7 +649,7 @@ describe("ProviderCard", () => {
     vi.useRealTimers()
   })
 
-  it("shows over-limit now detail when already at or above 100%", () => {
+  it("drops the pace indicator entirely once the limit is reached", () => {
     vi.useFakeTimers()
     const now = new Date("2026-02-02T12:00:00.000Z")
     vi.setSystemTime(now)
@@ -670,10 +670,43 @@ describe("ProviderCard", () => {
         ]}
       />
     )
-    expect(screen.getByLabelText("Limit reached")).toBeInTheDocument()
-    expect(screen.getByText("Limit reached")).toBeInTheDocument()
+    // No flame, no dot, no "Limit reached" affordance — the full bar says it.
+    expect(screen.queryByLabelText("Limit reached")).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Will run out")).not.toBeInTheDocument()
+    expect(document.querySelector("[data-pace-status]")).toBeNull()
+    // Deficit / runs-out detail stays suppressed past the limit.
     expect(screen.queryByText(/in deficit/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/runs out in/i)).not.toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
+  it("exposes an expected-pace tooltip on the grey marker", () => {
+    vi.useFakeTimers()
+    const now = new Date("2026-02-02T12:00:00.000Z")
+    vi.setSystemTime(now)
+    render(
+      <ProviderCard
+        name="Pace"
+        displayMode="used"
+        lines={[
+          {
+            type: "progress",
+            label: "Behind",
+            used: 60,
+            limit: 100,
+            format: { kind: "percent" },
+            resetsAt: "2026-02-03T00:00:00.000Z",
+            periodDurationMs: 24 * 60 * 60 * 1000,
+          },
+        ]}
+      />
+    )
+    const marker = document.querySelector<HTMLElement>('[data-slot="progress-marker"]')
+    expect(marker).toBeTruthy()
+    // Half the 24h period has elapsed at 12:00 → marker is interactive, not decorative.
+    expect(marker).not.toHaveClass("pointer-events-none")
+    expect(screen.getByText("Expected pace")).toBeInTheDocument()
+    expect(screen.getByText("50% of the period has elapsed")).toBeInTheDocument()
     vi.useRealTimers()
   })
 

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -68,16 +68,20 @@ function PaceIndicator({
   detailText?: string | null
   isLimitReached?: boolean
 }) {
+  // Once the limit is actually reached, drop the indicator entirely. The full
+  // bar and the 100% value already say it, and the flame reads as "running
+  // hot" — the wrong signal for a state that has already maxed out.
+  if (isLimitReached) return null
+
   const statusText = getPaceStatusText(status)
   const isBehind = status === "behind"
-  const ariaLabel = isLimitReached ? "Limit reached" : statusText
 
   return (
     <Tooltip>
       <TooltipTrigger
         render={(props) =>
           isBehind ? (
-            <span {...props} data-pace-status={status} className="inline-flex items-center" aria-label={ariaLabel}>
+            <span {...props} data-pace-status={status} className="inline-flex items-center" aria-label={statusText}>
               <Flame className="h-3.5 w-3.5 text-red-500" />
             </span>
           ) : (
@@ -85,20 +89,14 @@ function PaceIndicator({
               {...props}
               data-pace-status={status}
               className={`inline-block w-2 h-2 rounded-full ${PACE_DOT_CLASS[status]}`}
-              aria-label={ariaLabel}
+              aria-label={statusText}
             />
           )
         }
       />
       <TooltipContent side="top" className="text-xs text-center">
-        {isLimitReached ? (
-          "Limit reached"
-        ) : (
-          <>
-            <div>{statusText}</div>
-            {detailText && <div className="text-[10px] opacity-60">{detailText}</div>}
-          </>
-        )}
+        <div>{statusText}</div>
+        {detailText && <div className="text-[10px] opacity-60">{detailText}</div>}
       </TooltipContent>
     </Tooltip>
   )
@@ -623,14 +621,22 @@ function MetricLineRenderer({
       ? calculatePaceStatus(line.used, line.limit, resetsAtMs, periodDurationMs!, now)
       : null
     const paceStatus = paceResult?.status ?? null
-    const paceMarkerValue = hasTimeMarkerContext && paceStatus && paceStatus !== "on-track"
-      ? (() => {
-          const periodStartMs = resetsAtMs - periodDurationMs!
-          const elapsedFraction = clamp01((now - periodStartMs) / periodDurationMs!)
-          const elapsedPercent = elapsedFraction * 100
-          return displayMode === "used" ? elapsedPercent : 100 - elapsedPercent
-        })()
-      : undefined
+    // The grey marker sits at the fraction of the period that has elapsed, so
+    // the bar fill can be read against the passage of time. It only appears
+    // when off-track (ahead/behind), matching the pace indicator.
+    const showPaceMarker = hasTimeMarkerContext && !!paceStatus && paceStatus !== "on-track"
+    const elapsedPercent = showPaceMarker
+      ? clamp01((now - (resetsAtMs - periodDurationMs!)) / periodDurationMs!) * 100
+      : null
+    const paceMarkerValue =
+      elapsedPercent !== null ? (displayMode === "used" ? elapsedPercent : 100 - elapsedPercent) : undefined
+    const markerTooltip =
+      elapsedPercent !== null ? (
+        <>
+          <div>Expected pace</div>
+          <div className="text-[10px] opacity-60">{Math.round(elapsedPercent)}% of the period has elapsed</div>
+        </>
+      ) : undefined
     const isLimitReached = line.used >= line.limit
     const paceDetailText =
       hasPaceContext && !isLimitReached
@@ -674,6 +680,7 @@ function MetricLineRenderer({
           value={percent}
           indicatorColor={line.color ?? undefined}
           markerValue={paceMarkerValue}
+          markerTooltip={markerTooltip}
           refreshing={refreshing}
         />
         <div className="flex justify-between items-center mt-1.5">

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,16 +1,18 @@
 import * as React from "react"
 
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
 
 interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
   value?: number
   indicatorColor?: string
   markerValue?: number
+  markerTooltip?: React.ReactNode
   refreshing?: boolean
 }
 
 const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
-  ({ className, value = 0, indicatorColor, markerValue, refreshing, ...props }, ref) => {
+  ({ className, value = 0, indicatorColor, markerValue, markerTooltip, refreshing, ...props }, ref) => {
     const clamped = Math.min(100, Math.max(0, value))
     const clampedMarker =
       typeof markerValue === "number" && Number.isFinite(markerValue)
@@ -49,14 +51,31 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
           className="h-full transition-all bg-primary"
           style={{ width: `${clamped}%`, ...indicatorStyle }}
         />
-        {showMarker && (
-          <div
-            data-slot="progress-marker"
-            aria-hidden="true"
-            className="absolute top-0 bottom-0 w-1 z-10 pointer-events-none rounded-sm bg-muted-foreground ring-1 ring-background/50"
-            style={markerStyle}
-          />
-        )}
+        {showMarker &&
+          (markerTooltip != null ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={(triggerProps) => (
+                  <div
+                    {...triggerProps}
+                    data-slot="progress-marker"
+                    className="absolute top-0 bottom-0 w-1 z-10 cursor-help rounded-sm bg-muted-foreground ring-1 ring-background/50"
+                    style={markerStyle}
+                  />
+                )}
+              />
+              <TooltipContent side="top" className="text-xs text-center">
+                {markerTooltip}
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <div
+              data-slot="progress-marker"
+              aria-hidden="true"
+              className="absolute top-0 bottom-0 w-1 z-10 pointer-events-none rounded-sm bg-muted-foreground ring-1 ring-background/50"
+              style={markerStyle}
+            />
+          ))}
         {refreshing && (
           <div
             data-slot="progress-refreshing"

--- a/src/hooks/app/use-settings-bootstrap.test.ts
+++ b/src/hooks/app/use-settings-bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const {
   arePluginSettingsEqualMock,
@@ -128,6 +128,10 @@ function createArgs() {
 }
 
 describe("useSettingsBootstrap", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   beforeEach(() => {
     invokeMock.mockReset()
     isTauriMock.mockReset()
@@ -190,6 +194,7 @@ describe("useSettingsBootstrap", () => {
   })
 
   it("disables autostart when applyStartOnLogin receives false", async () => {
+    vi.stubEnv("DEV", false) // production build: autostart reconciliation is active
     const args = createArgs()
     const { result } = renderHook(() => useSettingsBootstrap(args))
 

--- a/src/hooks/app/use-settings-display-actions.ts
+++ b/src/hooks/app/use-settings-display-actions.ts
@@ -26,6 +26,7 @@ type UseSettingsDisplayActionsArgs = {
   menubarIconStyle: MenubarIconStyle
   multiTrayProviderCount: MultiTrayProviderCount
   setThemeMode: (value: ThemeMode) => void
+  displayMode: DisplayMode
   setDisplayMode: (value: DisplayMode) => void
   resetTimerDisplayMode: ResetTimerDisplayMode
   setResetTimerDisplayMode: (value: ResetTimerDisplayMode) => void
@@ -42,6 +43,7 @@ export function useSettingsDisplayActions({
   menubarIconStyle,
   multiTrayProviderCount,
   setThemeMode,
+  displayMode,
   setDisplayMode,
   resetTimerDisplayMode,
   setResetTimerDisplayMode,
@@ -67,6 +69,11 @@ export function useSettingsDisplayActions({
       console.error("Failed to save display mode:", error)
     })
   }, [scheduleTrayIconUpdate, setDisplayMode])
+
+  const handleDisplayModeToggle = useCallback(() => {
+    const next: DisplayMode = displayMode === "used" ? "left" : "used"
+    handleDisplayModeChange(next)
+  }, [displayMode, handleDisplayModeChange])
 
   const handleResetTimerDisplayModeChange = useCallback((mode: ResetTimerDisplayMode) => {
     setResetTimerDisplayMode(mode)
@@ -145,6 +152,7 @@ export function useSettingsDisplayActions({
   return {
     handleThemeModeChange,
     handleDisplayModeChange,
+    handleDisplayModeToggle,
     handleResetTimerDisplayModeChange,
     handleResetTimerDisplayModeToggle,
     handleTimeFormatModeChange,

--- a/src/lib/autostart.test.ts
+++ b/src/lib/autostart.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const isTauriMock = vi.fn()
+const enableMock = vi.fn()
+const disableMock = vi.fn()
+const isEnabledMock = vi.fn()
+
+vi.mock("@tauri-apps/api/core", () => ({
+  isTauri: () => isTauriMock(),
+}))
+vi.mock("@tauri-apps/plugin-autostart", () => ({
+  enable: () => enableMock(),
+  disable: () => disableMock(),
+  isEnabled: () => isEnabledMock(),
+}))
+
+import { syncAutostart } from "./autostart"
+
+describe("syncAutostart", () => {
+  beforeEach(() => {
+    isTauriMock.mockReset().mockReturnValue(true)
+    enableMock.mockReset().mockResolvedValue(undefined)
+    disableMock.mockReset().mockResolvedValue(undefined)
+    isEnabledMock.mockReset().mockResolvedValue(false)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("no-ops outside Tauri", async () => {
+    vi.stubEnv("DEV", false)
+    isTauriMock.mockReturnValue(false)
+    await syncAutostart(true)
+    expect(isEnabledMock).not.toHaveBeenCalled()
+    expect(enableMock).not.toHaveBeenCalled()
+  })
+
+  it("never touches the OS from a dev build (would register the ephemeral dev binary)", async () => {
+    vi.stubEnv("DEV", true)
+    await syncAutostart(true)
+    expect(isEnabledMock).not.toHaveBeenCalled()
+    expect(enableMock).not.toHaveBeenCalled()
+    expect(disableMock).not.toHaveBeenCalled()
+  })
+
+  it("enables when on and the OS is not yet registered (release build)", async () => {
+    vi.stubEnv("DEV", false)
+    isEnabledMock.mockResolvedValue(false)
+    await syncAutostart(true)
+    expect(enableMock).toHaveBeenCalledTimes(1)
+    expect(disableMock).not.toHaveBeenCalled()
+  })
+
+  it("skips the native call when the OS already matches", async () => {
+    vi.stubEnv("DEV", false)
+    isEnabledMock.mockResolvedValue(true)
+    await syncAutostart(true)
+    expect(enableMock).not.toHaveBeenCalled()
+    expect(disableMock).not.toHaveBeenCalled()
+  })
+
+  it("disables when off and the OS is currently registered", async () => {
+    vi.stubEnv("DEV", false)
+    isEnabledMock.mockResolvedValue(true)
+    await syncAutostart(false)
+    expect(disableMock).toHaveBeenCalledTimes(1)
+    expect(enableMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/autostart.ts
+++ b/src/lib/autostart.ts
@@ -6,9 +6,16 @@ import {
 } from "@tauri-apps/plugin-autostart"
 
 /** Sync the OS launch-at-login registration to `value`, skipping the native
- * call when it already matches. No-op outside Tauri. */
+ * call when it already matches. No-op outside Tauri.
+ *
+ * Dev builds are deliberately excluded: tauri-plugin-autostart registers
+ * `current_exe()`, which for a dev build is an ephemeral `target/debug` binary
+ * inside a worktree. That path can't launch standalone at login (it needs the
+ * Vite dev server), so registering it writes a broken login item that fails on
+ * every login. Only the installed release app should own the login item. */
 export async function syncAutostart(value: boolean): Promise<void> {
   if (!isTauri()) return
+  if (import.meta.env.DEV) return
   if ((await isAutostartEnabled()) === value) return
   if (value) {
     await enableAutostart()

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -11,6 +11,7 @@ interface OverviewPageProps {
   timeFormatMode?: TimeFormatMode
   overviewSpendStripEnabled?: boolean
   onResetTimerDisplayModeToggle?: () => void
+  onUsageValueToggle?: () => void
 }
 
 export function OverviewPage({
@@ -21,6 +22,7 @@ export function OverviewPage({
   timeFormatMode = "auto",
   overviewSpendStripEnabled = true,
   onResetTimerDisplayModeToggle,
+  onUsageValueToggle,
 }: OverviewPageProps) {
   return (
     <div>
@@ -54,6 +56,7 @@ export function OverviewPage({
               resetTimerDisplayMode={resetTimerDisplayMode}
               timeFormatMode={timeFormatMode}
               onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
+              onUsageValueToggle={onUsageValueToggle}
             />
           ))}
         </>

--- a/src/pages/provider-detail.tsx
+++ b/src/pages/provider-detail.tsx
@@ -9,6 +9,7 @@ interface ProviderDetailPageProps {
   resetTimerDisplayMode: ResetTimerDisplayMode
   timeFormatMode?: TimeFormatMode
   onResetTimerDisplayModeToggle?: () => void
+  onUsageValueToggle?: () => void
 }
 
 export function ProviderDetailPage({
@@ -18,6 +19,7 @@ export function ProviderDetailPage({
   resetTimerDisplayMode,
   timeFormatMode = "auto",
   onResetTimerDisplayModeToggle,
+  onUsageValueToggle,
 }: ProviderDetailPageProps) {
   if (!plugin) {
     return (
@@ -45,6 +47,7 @@ export function ProviderDetailPage({
       resetTimerDisplayMode={resetTimerDisplayMode}
       timeFormatMode={timeFormatMode}
       onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
+      onUsageValueToggle={onUsageValueToggle}
     />
   )
 }


### PR DESCRIPTION
Beta 2 of the 0.7.35 line (on top of the beta.1 native pricing engine).

## Changes
**UI (usage bars)**
- Click the `% used` / `% left` text to flip between them (persisted) — mirrors the reset-timer text toggle.
- Hover the grey pace marker to see "Expected pace — N% of the period has elapsed".
- The flame is dropped once a limit is reached (the full bar already says it).

**Fix**
- Start on login no longer registers a dev build's throwaway binary; only the installed app manages the login item. Root cause: `tauri-plugin-autostart` registers `current_exe()`, which for a dev build is an ephemeral `target/debug` path that fails at login.

## Verification
- 1799 JS tests pass, `tsc` clean.
- New `autostart.test.ts`; prod-path autostart tests updated to assert real reconciliation.

Ships to the beta channel via the `v0.7.35-beta.2` tag (prerelease). Stable `v0.7.35` to follow after field soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)