### PR TITLE
fix(codex): Fix Codex business credits usage

### DIFF
--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -55,6 +55,16 @@ Returns rate limit windows and optional credits.
     "unlimited": false,
     "balance": 820.6969075                 // remaining credits
   },
+  "spend_control": {                       // Business workspace limit (optional)
+    "individual_limit": {
+      "limit": "15000",                   // monthly credit allowance
+      "used": "3831.746052503586",
+      "remaining": "11168.253947496414",
+      "used_percent": 26,
+      "remaining_percent": 74,
+      "reset_at": 1785542400
+    }
+  },
   "rate_limit_reset_credits": {            // on-demand resets count only (optional)
     "available_count": 1
   }
@@ -66,6 +76,11 @@ Both rate_limit windows are enforced simultaneously — hitting either limit thr
 UsagePal floors the remaining credit balance to a whole number and displays its fixed USD
 equivalent at `$0.04` per credit. For example, `820.6969075` renders as
 `$32.80 · 820 credits`. The credit balance is unbounded; the API does not provide a maximum.
+
+Business workspaces may hide the purchased-credit balance and return a monthly per-member limit
+under `spend_control.individual_limit` instead. UsagePal shows that allowance as a **Monthly Credit
+Limit** meter using the reported `used`, `limit`, and reset time, without treating a missing balance
+as zero credits.
 
 ### GET /backend-api/wham/rate-limit-reset-credits
 

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -80,7 +80,8 @@ equivalent at `$0.04` per credit. For example, `820.6969075` renders as
 Business workspaces may hide the purchased-credit balance and return a monthly per-member limit
 under `spend_control.individual_limit` instead. UsagePal shows that allowance as a **Monthly Credit
 Limit** meter using the reported `used`, `limit`, and reset time, without treating a missing balance
-as zero credits.
+as zero credits. Credit amounts are rounded to whole credits. The meter appears in both the overview
+and Codex detail views.
 
 ### GET /backend-api/wham/rate-limit-reset-credits
 

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -406,8 +406,20 @@
   }
 
   function readNumber(value) {
+    if (value == null || (typeof value === "string" && !value.trim())) return null
     const n = Number(value)
     return Number.isFinite(n) ? n : null
+  }
+
+  function readMonthlyCreditLimit(data) {
+    const individualLimit = data?.spend_control?.individual_limit
+    if (!individualLimit || typeof individualLimit !== "object") return null
+
+    const limit = readNumber(individualLimit.limit)
+    const used = readNumber(individualLimit.used)
+    if (limit === null || limit <= 0 || used === null || used < 0) return null
+
+    return { limit: limit, used: used, window: individualLimit }
   }
 
   function readCreditsRemaining(resp, data) {
@@ -986,6 +998,17 @@
         lines.push(ctx.line.text({
           label: "Credits",
           value: "$" + usdValue + " · " + remaining + " credits",
+        }))
+      }
+
+      const monthlyCreditLimit = readMonthlyCreditLimit(data)
+      if (monthlyCreditLimit) {
+        lines.push(ctx.line.progress({
+          label: "Monthly Credit Limit",
+          used: monthlyCreditLimit.used,
+          limit: monthlyCreditLimit.limit,
+          format: { kind: "count", suffix: "credits" },
+          resetsAt: getResetsAtIso(ctx, nowSec, monthlyCreditLimit.window),
         }))
       }
 

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -419,7 +419,7 @@
     const used = readNumber(individualLimit.used)
     if (limit === null || limit <= 0 || used === null || used < 0) return null
 
-    return { limit: limit, used: used, window: individualLimit }
+    return { limit: Math.round(limit), used: Math.round(used), window: individualLimit }
   }
 
   function readCreditsRemaining(resp, data) {

--- a/plugins/codex/plugin.json
+++ b/plugins/codex/plugin.json
@@ -23,7 +23,7 @@
     { "type": "progress", "label": "Reviews", "scope": "detail" },
     { "type": "text", "label": "Rate Limit Resets", "scope": "detail" },
     { "type": "text", "label": "Credits", "scope": "detail" },
-    { "type": "progress", "label": "Monthly Credit Limit", "scope": "detail" },
+    { "type": "progress", "label": "Monthly Credit Limit", "scope": "overview", "primaryOrder": 2 },
     { "type": "text", "label": "Today", "scope": "detail" },
     { "type": "text", "label": "Yesterday", "scope": "detail" },
     { "type": "text", "label": "Last 30 Days", "scope": "detail" },

--- a/plugins/codex/plugin.json
+++ b/plugins/codex/plugin.json
@@ -23,6 +23,7 @@
     { "type": "progress", "label": "Reviews", "scope": "detail" },
     { "type": "text", "label": "Rate Limit Resets", "scope": "detail" },
     { "type": "text", "label": "Credits", "scope": "detail" },
+    { "type": "progress", "label": "Monthly Credit Limit", "scope": "detail" },
     { "type": "text", "label": "Today", "scope": "detail" },
     { "type": "text", "label": "Yesterday", "scope": "detail" },
     { "type": "text", "label": "Last 30 Days", "scope": "detail" },

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -314,6 +314,53 @@ describe("codex plugin", () => {
     expect(credits.value).toBe("$0.00 · 0 credits")
   })
 
+  it("shows the monthly credit limit for business accounts with a hidden balance", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: { "x-codex-credits-balance": "" },
+      bodyText: JSON.stringify({
+        plan_type: "business",
+        credits: {
+          has_credits: true,
+          unlimited: false,
+          balance: null,
+        },
+        spend_control: {
+          reached: false,
+          individual_limit: {
+            source: "workspace_spend_controls",
+            limit: "15000",
+            used: "3831.746052503586",
+            remaining: "11168.253947496414",
+            used_percent: 26,
+            remaining_percent: 74,
+            reset_after_seconds: 920777,
+            reset_at: 1785542400,
+          },
+        },
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("Business")
+    expect(result.lines.find((line) => line.label === "Credits")).toBeUndefined()
+    expect(result.lines.find((line) => line.label === "Monthly Credit Limit")).toEqual({
+      type: "progress",
+      label: "Monthly Credit Limit",
+      used: 3831.746052503586,
+      limit: 15000,
+      format: { kind: "count", suffix: "credits" },
+      resetsAt: new Date(1785542400 * 1000).toISOString(),
+    })
+  })
+
   it("shows credit balances above 1000 without a fake cap", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { readFileSync } from "node:fs"
 import { makeCtx } from "../test-helpers.js"
 
 const loadPlugin = async () => {
@@ -45,6 +46,15 @@ describe("codex plugin", () => {
     const result = plugin.probe(ctx)
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
   }
+
+  it("declares the monthly credit limit as an overview primary metric", () => {
+    const manifest = JSON.parse(readFileSync("plugins/codex/plugin.json", "utf8"))
+    expect(manifest.lines.find((line) => line.label === "Monthly Credit Limit")).toMatchObject({
+      type: "progress",
+      scope: "overview",
+      primaryOrder: 2,
+    })
+  })
 
   it("throws when auth missing", async () => {
     const ctx = makeCtx()
@@ -354,7 +364,7 @@ describe("codex plugin", () => {
     expect(result.lines.find((line) => line.label === "Monthly Credit Limit")).toEqual({
       type: "progress",
       label: "Monthly Credit Limit",
-      used: 3831.746052503586,
+      used: 3832,
       limit: 15000,
       format: { kind: "count", suffix: "credits" },
       resetsAt: new Date(1785542400 * 1000).toISOString(),


### PR DESCRIPTION
## Description

Supports Codex limits from Business subscription (limits set by org per user)

## Related Issue

Closes https://github.com/Halloweedev/usagepal/issues/27

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Screenshots

<img width="400" height="364" alt="image" src="https://github.com/user-attachments/assets/123b7e32-17e7-479e-81d1-4b5daba13fe4" />

<img width="400" height="1152" alt="image" src="https://github.com/user-attachments/assets/642e30f7-6da3-4503-bd9c-a8a6cd5707e5" />


## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification
