### PR TITLE
feat(amp): Remove "Free" quota usage for Amp

### DIFF
--- a/docs/providers/amp.md
+++ b/docs/providers/amp.md
@@ -5,7 +5,7 @@
 - **Protocol:** JSON-RPC (`POST /api/internal`)
 - **URL:** `https://ampcode.com/api/internal`
 - **Auth:** API key from Amp CLI (`~/.local/share/amp/secrets.json`)
-- **Tier:** Free (daily quota), Megawatt/Gigawatt subscriptions, and/or individual credits
+- **Tier:** Megawatt/Gigawatt subscriptions and/or individual credits
 
 ## Authentication
 
@@ -37,17 +37,9 @@ Content-Type: application/json
 
 The response contains a `displayText` string whose contents vary by user tier:
 
-**Free tier + credits:**
-```
-Signed in as <user>
-Amp Free: <percent>% remaining today (resets daily) - https://ampcode.com/settings#amp-free
-Individual credits: $<credits> remaining - https://ampcode.com/settings
-```
-
 **Subscription:**
 ```
 Signed in as <user>
-Amp Free: <percent>% remaining today (resets daily) - https://ampcode.com/settings#amp-free
 Subscription <plan>: <percent>% other usage and <percent>% orb usage remaining
 ```
 
@@ -58,23 +50,15 @@ Individual credits: $<credits> remaining - https://ampcode.com/settings
 ```
 
 The plugin parses the display text with regex to extract:
-- **Free quota:** `<percent>% remaining today` → daily percentage remaining
 - **Subscription:** plan name, other usage remaining, and orb usage remaining
 - **Credits:** `Individual credits: $N remaining` → paid credits balance
-
-### Usage Calculation (Free tier only)
-
-- **Used:** `100 - percent remaining` (clamped between 0% and 100%)
-- **Reset time:** Not supplied by the API; the response only states that it resets daily
-- **Period:** 24 hours (fixed)
 
 ## Plan Detection
 
 | Condition | Plan |
 |-----------|------|
 | Subscription present | Subscription plan name, such as `"Megawatt"` |
-| Free tier present (with or without credits) | `"Free"` |
-| Credits only (no free tier) | `"Credits"` |
+| No subscription | `"Credits"` |
 
 ## Displayed Lines
 
@@ -82,13 +66,7 @@ The plugin parses the display text with regex to extract:
 |-------------|----------|-----------------------------|----------------------------------------|
 | Subscription Usage | overview | Subscription enabled        | Included non-orb subscription usage consumed |
 | Orb Usage   | overview | Subscription enabled        | Included orb usage consumed            |
-| Free        | overview | Amp Free enabled            | Daily usage consumed as a percentage progress bar |
 | Credits     | overview | Credits > $0, or credits-only accounts | Individual credits balance      |
-
-The Free progress line includes:
-- `periodDurationMs` — 24 hours for pace tracking
-
-The API does not provide exact reset times, so the progress lines do not include `resetsAt`.
 
 ## Errors
 

--- a/plugins/amp/plugin.js
+++ b/plugins/amp/plugin.js
@@ -39,48 +39,10 @@
     if (!text || typeof text !== "string") return null
 
     var result = {
-      remainingPct: null,
-      remaining: null,
-      total: null,
-      hourlyRate: 0,
-      bonusPct: null,
-      bonusDays: null,
       credits: null,
       subscriptionPlan: null,
       otherRemainingPct: null,
       orbRemainingPct: null,
-    }
-
-    var percentMatch = text.match(/Amp Free: ([0-9]+(?:\.[0-9]+)?)% remaining today/)
-    if (percentMatch) {
-      var remainingPct = Number(percentMatch[1])
-      if (Number.isFinite(remainingPct)) result.remainingPct = remainingPct
-    }
-
-    var balanceMatch = text.match(/\$([0-9][0-9,]*(?:\.[0-9]+)?)\/\$([0-9][0-9,]*(?:\.[0-9]+)?) remaining/)
-    if (balanceMatch) {
-      var remaining = parseMoney(balanceMatch[1])
-      var total = parseMoney(balanceMatch[2])
-      if (Number.isFinite(remaining) && Number.isFinite(total)) {
-        result.remaining = remaining
-        result.total = total
-      }
-    }
-
-    var rateMatch = text.match(/replenishes \+\$([0-9][0-9,]*(?:\.[0-9]+)?)\/hour/)
-    if (rateMatch) {
-      var rate = parseMoney(rateMatch[1])
-      if (Number.isFinite(rate)) result.hourlyRate = rate
-    }
-
-    var bonusMatch = text.match(/\+(\d+)% bonus for (\d+) more days?/)
-    if (bonusMatch) {
-      var pct = Number(bonusMatch[1])
-      var days = Number(bonusMatch[2])
-      if (Number.isFinite(pct) && Number.isFinite(days)) {
-        result.bonusPct = pct
-        result.bonusDays = days
-      }
     }
 
     var creditsMatch = text.match(/Individual credits: \$([0-9][0-9,]*(?:\.[0-9]+)?) remaining/)
@@ -100,7 +62,7 @@
       }
     }
 
-    if (result.remainingPct === null && result.total === null && result.credits === null && result.subscriptionPlan === null) return null
+    if (result.credits === null && result.subscriptionPlan === null) return null
 
     return result
   }
@@ -142,19 +104,19 @@
 
     var balance = parseBalanceText(json.result.displayText)
     if (!balance) {
-      if (/Amp Free|Subscription /.test(json.result.displayText)) {
+      if (/Subscription /.test(json.result.displayText)) {
         ctx.host.log.error("failed to parse Amp usage display text")
         throw "Could not parse usage data."
       }
       ctx.host.log.warn("no balance data found, assuming credits-only")
-      balance = { remainingPct: null, remaining: null, total: null, hourlyRate: 0, bonusPct: null, bonusDays: null, credits: 0, subscriptionPlan: null, otherRemainingPct: null, orbRemainingPct: null }
+      balance = { credits: 0, subscriptionPlan: null, otherRemainingPct: null, orbRemainingPct: null }
     } else if (/Subscription /.test(json.result.displayText) && balance.subscriptionPlan === null) {
       ctx.host.log.error("failed to parse Amp subscription display text")
       throw "Could not parse usage data."
     }
 
     var lines = []
-    var plan = balance.subscriptionPlan || "Free"
+    var plan = balance.subscriptionPlan || "Credits"
 
     if (balance.subscriptionPlan !== null) {
       lines.push(ctx.line.progress({
@@ -171,45 +133,7 @@
       }))
     }
 
-    if (balance.remainingPct !== null) {
-      lines.push(ctx.line.progress({
-        label: "Free",
-        used: Math.min(100, Math.max(0, 100 - balance.remainingPct)),
-        limit: 100,
-        format: { kind: "percent" },
-        periodDurationMs: 24 * 3600 * 1000,
-      }))
-    } else if (balance.total !== null) {
-      var used = Math.max(0, balance.total - balance.remaining)
-      var total = balance.total
-
-      var resetsAtMs = null
-      if (used > 0 && balance.hourlyRate > 0) {
-        var hoursToFull = used / balance.hourlyRate
-        resetsAtMs = Date.now() + hoursToFull * 3600 * 1000
-      }
-
-      lines.push(ctx.line.progress({
-        label: "Free",
-        used: used,
-        limit: total,
-        format: { kind: "dollars" },
-        resetsAt: ctx.util.toIso(resetsAtMs),
-        periodDurationMs: 24 * 3600 * 1000,
-      }))
-
-      if (balance.bonusPct && balance.bonusDays) {
-        lines.push(ctx.line.text({
-          label: "Bonus",
-          value: "+" + balance.bonusPct + "% for " + balance.bonusDays + "d",
-        }))
-      }
-    }
-
-    var hasFreeTier = balance.remainingPct !== null || balance.total !== null
-    if (balance.credits !== null && !hasFreeTier && balance.subscriptionPlan === null) plan = "Credits"
-
-    if (balance.credits !== null && (balance.credits > 0 || !hasFreeTier)) {
+    if (balance.credits !== null && (balance.credits > 0 || balance.subscriptionPlan === null)) {
       lines.push(ctx.line.text({
         label: "Credits",
         value: "$" + balance.credits.toFixed(2),

--- a/plugins/amp/plugin.json
+++ b/plugins/amp/plugin.json
@@ -10,8 +10,6 @@
   "lines": [
     { "type": "progress", "label": "Subscription Usage", "scope": "overview", "primaryOrder": 1 },
     { "type": "progress", "label": "Orb Usage", "scope": "overview", "primaryOrder": 2 },
-    { "type": "progress", "label": "Free", "scope": "overview", "primaryOrder": 3 },
-    { "type": "text", "label": "Bonus", "scope": "detail" },
     { "type": "text", "label": "Credits", "scope": "overview" }
   ]
 }

--- a/plugins/amp/plugin.test.js
+++ b/plugins/amp/plugin.test.js
@@ -23,24 +23,6 @@ function balanceResponse(displayText) {
   }
 }
 
-function standardDisplayText(opts) {
-  opts = opts || {}
-  var remaining = opts.remaining !== undefined ? opts.remaining : 1.66
-  var total = opts.total !== undefined ? opts.total : 20
-  var rate = opts.rate !== undefined ? opts.rate : 0.83
-  var text = "Signed in as user@test.com (testuser)\n"
-  text += "Amp Free: $" + remaining + "/$" + total + " remaining (replenishes +$" + rate + "/hour)"
-  if (opts.bonus !== false) {
-    var pct = opts.bonusPct || 100
-    var days = opts.bonusDays || 2
-    text += " [+" + pct + "% bonus for " + days + " more days]"
-  }
-  text += " - https://ampcode.com/settings#amp-free\n"
-  var credits = opts.credits !== undefined ? opts.credits : 0
-  text += "Individual credits: $" + credits + " remaining - https://ampcode.com/settings"
-  return text
-}
-
 describe("amp plugin", () => {
   beforeEach(() => {
     delete globalThis.__openusage_plugin
@@ -74,7 +56,7 @@ describe("amp plugin", () => {
   it("sends POST with Bearer auth to api/internal", async () => {
     var ctx = makeCtx()
     writeSecrets(ctx, "my-api-key")
-    ctx.host.http.request.mockReturnValue(balanceResponse(standardDisplayText()))
+    ctx.host.http.request.mockReturnValue(balanceResponse("Individual credits: $0 remaining"))
     var plugin = await loadPlugin()
     plugin.probe(ctx)
     var call = ctx.host.http.request.mock.calls[0][0]
@@ -153,49 +135,18 @@ describe("amp plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Could not parse usage data")
   })
 
-  it("throws when free tier present but unparseable", async () => {
-    var ctx = makeCtx()
-    writeSecrets(ctx)
-    ctx.host.http.request.mockReturnValue(balanceResponse("Amp Free: unparseable data"))
-    var plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Could not parse usage data")
-  })
-
   // --- Balance parsing ---
-
-  it("parses the current daily percentage response", async () => {
-    var ctx = makeCtx()
-    writeSecrets(ctx)
-    var text = "Signed in as user@test.com (testuser)\n"
-      + "Amp Free: 48% remaining today (resets daily) - https://ampcode.com/settings#amp-free\n"
-      + "Individual credits: $0 remaining - https://ampcode.com/settings"
-    ctx.host.http.request.mockReturnValue(balanceResponse(text))
-    var plugin = await loadPlugin()
-    var result = plugin.probe(ctx)
-    expect(result.plan).toBe("Free")
-    expect(result.lines).toHaveLength(1)
-    expect(result.lines[0]).toMatchObject({
-      type: "progress",
-      label: "Free",
-      used: 52,
-      limit: 100,
-      format: { kind: "percent" },
-      periodDurationMs: 24 * 3600 * 1000,
-    })
-    expect(result.lines[0].resetsAt).toBeUndefined()
-  })
 
   it("parses subscription usage pools", async () => {
     var ctx = makeCtx()
     writeSecrets(ctx)
     var text = "Signed in as user@test.com (testuser)\n"
-      + "Amp Free: 100% remaining today (resets daily) - https://ampcode.com/settings#amp-free\n"
       + "Subscription Megawatt: 100% other usage and 100% orb usage remaining"
     ctx.host.http.request.mockReturnValue(balanceResponse(text))
     var plugin = await loadPlugin()
     var result = plugin.probe(ctx)
     expect(result.plan).toBe("Megawatt")
-    expect(result.lines).toHaveLength(3)
+    expect(result.lines).toHaveLength(2)
     expect(result.lines[0]).toMatchObject({
       type: "progress",
       label: "Subscription Usage",
@@ -210,65 +161,21 @@ describe("amp plugin", () => {
       limit: 100,
       format: { kind: "percent" },
     })
-    expect(result.lines[2]).toMatchObject({ label: "Free", used: 0 })
   })
 
   it("throws when subscription usage is present but unparseable", async () => {
     var ctx = makeCtx()
     writeSecrets(ctx)
-    var text = "Amp Free: 100% remaining today\nSubscription Megawatt: unparseable data"
+    var text = "Subscription Megawatt: unparseable data"
     ctx.host.http.request.mockReturnValue(balanceResponse(text))
     var plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Could not parse usage data")
   })
 
-  it("parses standard balance text", async () => {
-    var ctx = makeCtx()
-    writeSecrets(ctx)
-    ctx.host.http.request.mockReturnValue(balanceResponse(standardDisplayText({
-      remaining: 1.66, total: 20, rate: 0.83,
-    })))
-    var plugin = await loadPlugin()
-    var result = plugin.probe(ctx)
-    var line = result.lines[0]
-    expect(line.type).toBe("progress")
-    expect(line.label).toBe("Free")
-    expect(line.used).toBeCloseTo(18.34, 2)
-    expect(line.limit).toBe(20)
-    expect(line.format.kind).toBe("dollars")
-  })
-
-  it("parses balance with no bonus bracket", async () => {
-    var ctx = makeCtx()
-    writeSecrets(ctx)
-    ctx.host.http.request.mockReturnValue(balanceResponse(standardDisplayText({
-      remaining: 10, total: 20, rate: 0.83, bonus: false,
-    })))
-    var plugin = await loadPlugin()
-    var result = plugin.probe(ctx)
-    expect(result.lines.length).toBe(1)
-    expect(result.lines[0].used).toBe(10)
-  })
-
-  it("includes bonus text line when present", async () => {
-    var ctx = makeCtx()
-    writeSecrets(ctx)
-    ctx.host.http.request.mockReturnValue(balanceResponse(standardDisplayText({
-      bonusPct: 100, bonusDays: 2,
-    })))
-    var plugin = await loadPlugin()
-    var result = plugin.probe(ctx)
-    var bonusLine = result.lines.find(function (l) { return l.label === "Bonus" })
-    expect(bonusLine).toBeTruthy()
-    expect(bonusLine.value).toBe("+100% for 2d")
-  })
-
   it("includes credits text line when credits > 0", async () => {
     var ctx = makeCtx()
     writeSecrets(ctx)
-    ctx.host.http.request.mockReturnValue(balanceResponse(standardDisplayText({
-      credits: 5.50,
-    })))
+    ctx.host.http.request.mockReturnValue(balanceResponse("Individual credits: $5.50 remaining"))
     var plugin = await loadPlugin()
     var result = plugin.probe(ctx)
     var creditsLine = result.lines.find(function (l) { return l.label === "Credits" })
@@ -276,77 +183,14 @@ describe("amp plugin", () => {
     expect(creditsLine.value).toBe("$5.50")
   })
 
-  it("omits credits line when credits are zero", async () => {
+  it("shows credits line when credits-only balance is zero", async () => {
     var ctx = makeCtx()
     writeSecrets(ctx)
-    ctx.host.http.request.mockReturnValue(balanceResponse(standardDisplayText({
-      credits: 0,
-    })))
+    ctx.host.http.request.mockReturnValue(balanceResponse("Individual credits: $0 remaining"))
     var plugin = await loadPlugin()
     var result = plugin.probe(ctx)
     var creditsLine = result.lines.find(function (l) { return l.label === "Credits" })
-    expect(creditsLine).toBeUndefined()
-  })
-
-  it("clamps used to 0 when remaining exceeds total", async () => {
-    var ctx = makeCtx()
-    writeSecrets(ctx)
-    ctx.host.http.request.mockReturnValue(balanceResponse(standardDisplayText({
-      remaining: 25, total: 20,
-    })))
-    var plugin = await loadPlugin()
-    var result = plugin.probe(ctx)
-    expect(result.lines[0].used).toBe(0)
-  })
-
-  // --- Reset time and period ---
-
-  it("returns resetsAt and periodDurationMs", async () => {
-    var ctx = makeCtx()
-    writeSecrets(ctx)
-    ctx.host.http.request.mockReturnValue(balanceResponse(standardDisplayText({
-      remaining: 1.66, total: 20, rate: 0.83,
-    })))
-    var plugin = await loadPlugin()
-    var result = plugin.probe(ctx)
-    var line = result.lines[0]
-    expect(line.resetsAt).toBeTruthy()
-    expect(line.periodDurationMs).toBe(24 * 3600 * 1000)
-  })
-
-  it("returns null resetsAt when nothing used", async () => {
-    var ctx = makeCtx()
-    writeSecrets(ctx)
-    ctx.host.http.request.mockReturnValue(balanceResponse(standardDisplayText({
-      remaining: 20, total: 20, rate: 0.83,
-    })))
-    var plugin = await loadPlugin()
-    var result = plugin.probe(ctx)
-    expect(result.lines[0].used).toBe(0)
-    expect(result.lines[0].resetsAt).toBeUndefined()
-  })
-
-  it("returns null resetsAt when hourly rate is zero", async () => {
-    var ctx = makeCtx()
-    writeSecrets(ctx)
-    ctx.host.http.request.mockReturnValue(balanceResponse(standardDisplayText({
-      remaining: 10, total: 20, rate: 0,
-    })))
-    var plugin = await loadPlugin()
-    var result = plugin.probe(ctx)
-    expect(result.lines[0].used).toBe(10)
-    expect(result.lines[0].resetsAt).toBeUndefined()
-  })
-
-  // --- Plan ---
-
-  it("returns Free as plan", async () => {
-    var ctx = makeCtx()
-    writeSecrets(ctx)
-    ctx.host.http.request.mockReturnValue(balanceResponse(standardDisplayText()))
-    var plugin = await loadPlugin()
-    var result = plugin.probe(ctx)
-    expect(result.plan).toBe("Free")
+    expect(creditsLine.value).toBe("$0.00")
   })
 
   // --- Credits only ---
@@ -378,22 +222,6 @@ describe("amp plugin", () => {
     expect(result.lines[0].value).toBe("$5.00")
   })
 
-  it("shows both free tier and credits when both present", async () => {
-    var ctx = makeCtx()
-    writeSecrets(ctx)
-    ctx.host.http.request.mockReturnValue(balanceResponse(standardDisplayText({
-      credits: 10,
-    })))
-    var plugin = await loadPlugin()
-    var result = plugin.probe(ctx)
-    expect(result.plan).toBe("Free")
-    var progressLine = result.lines.find(function (l) { return l.type === "progress" })
-    var creditsLine = result.lines.find(function (l) { return l.label === "Credits" })
-    expect(progressLine).toBeTruthy()
-    expect(creditsLine).toBeTruthy()
-    expect(creditsLine.value).toBe("$10.00")
-  })
-
   it("falls back to credits-only when no balance or credits parsed", async () => {
     var ctx = makeCtx()
     writeSecrets(ctx)
@@ -421,18 +249,14 @@ describe("amp plugin", () => {
     expect(result.lines[0].value).toBe("$0.00")
   })
 
-  // --- Regex resilience ---
-
-  it("parses balance with comma-formatted amounts", async () => {
+  it("parses credits with comma-formatted amounts", async () => {
     var ctx = makeCtx()
     writeSecrets(ctx)
     var text = "Signed in as user@test.com (testuser)\n"
-      + "Amp Free: $1,000.50/$2,000 remaining (replenishes +$0.83/hour) - https://ampcode.com/settings#amp-free\n"
-      + "Individual credits: $0 remaining - https://ampcode.com/settings"
+      + "Individual credits: $1,000.50 remaining - https://ampcode.com/settings"
     ctx.host.http.request.mockReturnValue(balanceResponse(text))
     var plugin = await loadPlugin()
     var result = plugin.probe(ctx)
-    expect(result.lines[0].limit).toBe(2000)
-    expect(result.lines[0].used).toBeCloseTo(999.50, 2)
+    expect(result.lines[0].value).toBe("$1000.50")
   })
 })


### PR DESCRIPTION
## Description

Amp doesn't provide Free usage anymore, they replaced it with subscriptions and gave every user with Free usage allowance 1 month of free subscription instead and discontinued it. So no need to support it anymore

## Related Issue

None

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [x] Documentation
- [ ] Performance improvement
- [x] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification
