### PR TITLE
fix(providers): OpenRouter window, Z.ai CREDIT_LIMIT, Copilot org credits, Cursor Grok 4.6

### DIFF
--- a/plugins/copilot/plugin.js
+++ b/plugins/copilot/plugin.js
@@ -286,6 +286,18 @@
       if (completionsLine) lines.push(completionsLine);
     }
 
+    // Org-managed seats billed by token consumption (`token_based_billing`) carry no percent meter, so
+    // both branches above produce nothing. They still report the personal credits consumed as a raw
+    // count, which we surface as a "Credits" count line rather than dropping it. Gated on the marker so
+    // genuinely-empty/error responses without it still fall through to the loud "No usage data" badge.
+    if (lines.length === 0 && data.token_based_billing === true) {
+      const premium = (snapshots && snapshots.premium_interactions) || data.premium_interactions;
+      const creditsUsed = premium ? numOrNull(premium.credits_used) : null;
+      if (creditsUsed !== null && creditsUsed > 0) {
+        lines.push(ctx.line.text({ label: "Credits", value: String(creditsUsed) }));
+      }
+    }
+
     if (lines.length === 0) {
       lines.push(
         ctx.line.badge({

--- a/plugins/copilot/plugin.test.js
+++ b/plugins/copilot/plugin.test.js
@@ -630,4 +630,83 @@ describe("copilot plugin", () => {
       expect(result.lines.find((l) => l.label === "Extra Usage")).toBeFalsy();
     });
   });
+
+  describe("org-managed token-based-billing seat", () => {
+    it("shows a Credits count from premium_interactions.credits_used when meters are empty", async () => {
+      const ctx = makePluginTestContext();
+      setKeychainToken(ctx, "tok");
+      // Org-managed seat: no usable percent meter (entitlement 0), but personal credits were consumed.
+      mockUsageOk(
+        ctx,
+        makeUsageResponse({
+          copilot_plan: "business",
+          token_based_billing: true,
+          quota_snapshots: {
+            premium_interactions: {
+              entitlement: 0,
+              remaining: 0,
+              credits_used: 1234,
+              quota_id: "premium",
+            },
+          },
+        }),
+      );
+      const plugin = await loadPlugin();
+      const result = plugin.probe(ctx);
+      const credits = result.lines.find((l) => l.label === "Credits");
+      expect(credits).toBeTruthy();
+      expect(credits.type).toBe("text");
+      expect(credits.value).toBe("1234");
+      // Must not fall through to the loud "No usage data" badge.
+      expect(result.lines.find((l) => l.text === "No usage data")).toBeFalsy();
+    });
+
+    it("still shows 'No usage data' for an empty payload without the token-based-billing marker", async () => {
+      const ctx = makePluginTestContext();
+      setKeychainToken(ctx, "tok");
+      // Same empty-meter shape and credits_used present, but NOT token-based-billing: fail loud.
+      mockUsageOk(
+        ctx,
+        makeUsageResponse({
+          copilot_plan: "business",
+          quota_snapshots: {
+            premium_interactions: {
+              entitlement: 0,
+              remaining: 0,
+              credits_used: 1234,
+              quota_id: "premium",
+            },
+          },
+        }),
+      );
+      const plugin = await loadPlugin();
+      const result = plugin.probe(ctx);
+      expect(result.lines.find((l) => l.label === "Credits")).toBeFalsy();
+      expect(result.lines[0].text).toBe("No usage data");
+    });
+
+    it("shows 'No usage data' for a token-based seat when credits_used is 0", async () => {
+      const ctx = makePluginTestContext();
+      setKeychainToken(ctx, "tok");
+      mockUsageOk(
+        ctx,
+        makeUsageResponse({
+          copilot_plan: "business",
+          token_based_billing: true,
+          quota_snapshots: {
+            premium_interactions: {
+              entitlement: 0,
+              remaining: 0,
+              credits_used: 0,
+              quota_id: "premium",
+            },
+          },
+        }),
+      );
+      const plugin = await loadPlugin();
+      const result = plugin.probe(ctx);
+      expect(result.lines.find((l) => l.label === "Credits")).toBeFalsy();
+      expect(result.lines[0].text).toBe("No usage data");
+    });
+  });
 });

--- a/plugins/cursor/plugin.js
+++ b/plugins/cursor/plugin.js
@@ -61,7 +61,10 @@
       "grok-4.3":             { input: 1.25, cache_write: null,  cache_read: 0.2,   output: 2.5,   apply_max_mode_uplift: true },
       // Grok 4.5 list rates (cache read $0.5/M as of 2026-07-22 docs). Fast keeps 2x.
       "grok-4.5":             { input: 2.0,  cache_write: null,  cache_read: 0.5,   output: 6.0,   apply_max_mode_uplift: true },
-      "grok-4.5-fast":        { input: 4.0,  cache_write: null,  cache_read: 0.4,   output: 18.0,  apply_max_mode_uplift: true },
+      "grok-4.5-fast":        { input: 4.0,  cache_write: null,  cache_read: 0.4,   output: 12.0,  apply_max_mode_uplift: true },
+      // Grok 4.6 list rates. Fast keeps 2x on input/cache/output.
+      "grok-4.6":             { input: 2.0,  cache_write: null,  cache_read: 0.5,   output: 6.0,   apply_max_mode_uplift: true },
+      "grok-4.6-fast":        { input: 4.0,  cache_write: null,  cache_read: 1.0,   output: 12.0,  apply_max_mode_uplift: true },
       "grok-build-0.1":       { input: 1.0,  cache_write: null,  cache_read: 0.2,   output: 2.0,   apply_max_mode_uplift: true },
       "kimi-k2.5":            { input: 0.6,  cache_write: null,  cache_read: 0.1,   output: 3.0,   apply_max_mode_uplift: true },
     },
@@ -112,6 +115,10 @@
       // High / High Fast are reasoning-effort suffixes on Cursor Grok CSV slugs.
       { pattern: "^grok-4\\.5.*(?:high-)?fast", canonical: "grok-4.5-fast" },
       { pattern: "^grok-4\\.5", canonical: "grok-4.5" },
+      // Grok 4.6 slugs come dashed or dotted (grok-4-6 / grok-4.6), with optional
+      // reasoning-effort ("high") and Auto-mode suffixes; `.*fast` catches Fast.
+      { pattern: "^grok-4[-.]6.*(?:high-)?fast", canonical: "grok-4.6-fast" },
+      { pattern: "^grok-4[-.]6", canonical: "grok-4.6" },
       { pattern: "^grok-build-0\\.1", canonical: "grok-build-0.1" },
       { pattern: "^kimi-k2\\.5", canonical: "kimi-k2.5" },
     ],

--- a/plugins/cursor/plugin.test.js
+++ b/plugins/cursor/plugin.test.js
@@ -1849,10 +1849,36 @@ describe("cursor pricing", () => {
       plugin.__test.resolveModelRates("auto-cost")
     )
     // CSV often prefixes Cursor first-party models and appends reasoning effort.
-    expect(plugin.__test.resolveModelRates("cursor-grok-4.5-high-fast").output).toBe(18.0)
+    expect(plugin.__test.resolveModelRates("cursor-grok-4.5-high-fast").output).toBe(12.0)
     expect(plugin.__test.resolveModelRates("cursor-grok-4.5-high").output).toBe(6.0)
-    expect(plugin.__test.resolveModelRates("grok-4.5-high-fast").output).toBe(18.0)
+    expect(plugin.__test.resolveModelRates("grok-4.5-high-fast").output).toBe(12.0)
     expect(plugin.__test.resolveModelRates("grok-4.5-high").output).toBe(6.0)
+  })
+
+  it("resolves Grok 4.6 tiers and reasoning/fast suffixes", async () => {
+    const plugin = await loadPlugin()
+    // Base and fast tiers, with Cursor's `cursor-` prefix and reasoning suffix.
+    expect(plugin.__test.resolveModelRates("cursor-grok-4.6-high").input).toBe(2.0)
+    expect(plugin.__test.resolveModelRates("cursor-grok-4.6-high-fast").input).toBe(4.0)
+    // Dashed slug variant resolves to the same 4.6 row as the dotted one.
+    expect(plugin.__test.resolveModelRates("grok-4-6")).toEqual(
+      plugin.__test.resolveModelRates("grok-4.6")
+    )
+    expect(plugin.__test.resolveModelRates("grok-4-6").input).toBe(2.0)
+    // Full 4.6 base rates.
+    expect(plugin.__test.resolveModelRates("grok-4.6")).toEqual({
+      input: 2.0, cache_write: null, cache_read: 0.5, output: 6.0, apply_max_mode_uplift: true,
+    })
+    // Full 4.6 fast rates.
+    expect(plugin.__test.resolveModelRates("grok-4.6-fast")).toEqual({
+      input: 4.0, cache_write: null, cache_read: 1.0, output: 12.0, apply_max_mode_uplift: true,
+    })
+  })
+
+  it("prices grok-4.5-fast output at 12.0", async () => {
+    const plugin = await loadPlugin()
+    expect(plugin.__test.resolveModelRates("grok-4.5-fast").output).toBe(12.0)
+    expect(plugin.__test.resolveModelRates("grok-4.5-high-fast").output).toBe(12.0)
   })
 
   it("returns null for an unknown slug", async () => {

--- a/plugins/openrouter/plugin.js
+++ b/plugins/openrouter/plugin.js
@@ -175,7 +175,9 @@
     if (limit !== null && limit > 0) {
       lines.push(ctx.line.progress({
         label: "Key Limit",
-        used: Math.max(0, num(data.usage) || 0),
+        // `usage` is lifetime spend and never resets; the meter should track the current window,
+        // so derive used from the credit limit minus what's left of it.
+        used: Math.max(0, limit - Math.max(0, num(data.limit_remaining) || 0)),
         limit: limit,
         format: { kind: "dollars" },
         periodDurationMs: MONTH_MS,

--- a/plugins/openrouter/plugin.test.js
+++ b/plugins/openrouter/plugin.test.js
@@ -127,7 +127,7 @@ describe("openrouter plugin", () => {
     const ctx = makeCtx()
     mockEnvKey(ctx, "k")
     mockEndpoints(ctx, {
-      key: { data: { is_free_tier: true, usage: 12, limit: 50 } },
+      key: { data: { is_free_tier: true, usage: 12, limit: 50, limit_remaining: 38 } },
     })
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
@@ -136,6 +136,31 @@ describe("openrouter plugin", () => {
     expect(keyLimit.used).toBe(12)
     expect(keyLimit.limit).toBe(50)
     expect(result.plan).toBe("Free tier")
+  })
+
+  it("derives Key Limit used from limit minus limit_remaining, not lifetime usage", async () => {
+    const ctx = makeCtx()
+    mockEnvKey(ctx, "k")
+    mockEndpoints(ctx, {
+      key: { data: { is_free_tier: false, usage: 12, limit: 5, limit_remaining: 3 } },
+    })
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const keyLimit = findLine(result, "Key Limit")
+    expect(keyLimit.type).toBe("progress")
+    expect(keyLimit.used).toBe(2)
+    expect(keyLimit.limit).toBe(5)
+  })
+
+  it("omits the Key Limit meter for an unlimited key (limit null)", async () => {
+    const ctx = makeCtx()
+    mockEnvKey(ctx, "k")
+    mockEndpoints(ctx, {
+      key: { data: { is_free_tier: false, usage: 40, limit: null } },
+    })
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(findLine(result, "Key Limit")).toBeUndefined()
   })
 
   it("still renders the balance when /key fails", async () => {

--- a/plugins/zai/plugin.js
+++ b/plugins/zai/plugin.js
@@ -5,6 +5,9 @@
   const PERIOD_MS = 5 * 60 * 60 * 1000
   const WEEK_MS = 7 * 24 * 60 * 60 * 1000
   const MONTH_MS = 30 * 24 * 60 * 60 * 1000
+  // Z.ai renamed the percentage quota type from TOKENS_LIMIT to CREDIT_LIMIT.
+  // Accept both so new and legacy payloads keep producing Session/Weekly lines.
+  const CREDIT_LIMIT_TYPES = ["CREDIT_LIMIT", "TOKENS_LIMIT"]
 
   function loadApiKey(ctx) {
     const zai = ctx.host.env.get("ZAI_API_KEY")
@@ -79,10 +82,11 @@
   }
 
   function findLimit(limits, type, unit) {
+    const types = Array.isArray(type) ? type : [type]
     let fallback = null
     for (let i = 0; i < limits.length; i++) {
       const item = limits[i]
-      if (item.type === type || item.name === type) {
+      if (types.indexOf(item.type) !== -1 || types.indexOf(item.name) !== -1) {
         if (unit === undefined) {
           return item
         }
@@ -117,7 +121,7 @@
       return { plan, lines }
     }
 
-    const tokenLimit = findLimit(limits, "TOKENS_LIMIT", 3)
+    const tokenLimit = findLimit(limits, CREDIT_LIMIT_TYPES, 3)
 
     if (!tokenLimit) {
       lines.push(ctx.line.badge({ label: "Session", text: "No usage data", color: "#a3a3a3" }))
@@ -139,7 +143,7 @@
     }
     lines.push(ctx.line.progress(progressOpts))
 
-    const weeklyTokenLimit = findLimit(limits, "TOKENS_LIMIT", 6)
+    const weeklyTokenLimit = findLimit(limits, CREDIT_LIMIT_TYPES, 6)
     if (weeklyTokenLimit) {
       const weeklyUsed = Number.isFinite(weeklyTokenLimit.percentage) ? weeklyTokenLimit.percentage : 0
       const weeklyResetsAt = weeklyTokenLimit.nextResetTime ? ctx.util.toIso(weeklyTokenLimit.nextResetTime) : undefined

--- a/plugins/zai/plugin.test.js
+++ b/plugins/zai/plugin.test.js
@@ -81,6 +81,41 @@ const QUOTA_RESPONSE_WITH_WEEKLY = {
   },
 }
 
+const QUOTA_RESPONSE_CREDIT_LIMIT = {
+  code: 200,
+  data: {
+    limits: [
+      {
+        type: "CREDIT_LIMIT",
+        usage: 800000000,
+        currentValue: 1900000,
+        percentage: 42,
+        nextResetTime: 1738368000000,
+        unit: 3,
+        number: 5,
+      },
+      {
+        type: "CREDIT_LIMIT",
+        usage: 1600000000,
+        currentValue: 4800000,
+        percentage: 63,
+        nextResetTime: 1738972800000,
+        unit: 6,
+        number: 7,
+      },
+      {
+        type: "TIME_LIMIT",
+        usage: 4000,
+        currentValue: 1095,
+        percentage: 27,
+        remaining: 2905,
+        unit: 5,
+        number: 1,
+      },
+    ],
+  },
+}
+
 const QUOTA_RESPONSE_NO_TIME_LIMIT = {
   code: 200,
   data: {
@@ -526,6 +561,38 @@ describe("zai plugin", () => {
     expect(session.resetsAt).toBe(new Date(1738368000000).toISOString())
     expect(weekly).toBeTruthy()
     expect(weekly.used).toBe(75)
+    expect(weekly.resetsAt).toBe(new Date(1738972800000).toISOString())
+  })
+
+  it("renders Session and Weekly from CREDIT_LIMIT payload (renamed from TOKENS_LIMIT)", async () => {
+    const ctx = makeCtx()
+    mockEnvWithKey(ctx, "test-key")
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (opts.url.includes("subscription")) {
+        return { status: 200, bodyText: JSON.stringify(SUBSCRIPTION_RESPONSE) }
+      }
+      return { status: 200, bodyText: JSON.stringify(QUOTA_RESPONSE_CREDIT_LIMIT) }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    const session = result.lines.find((l) => l.label === "Session")
+    expect(session).toBeTruthy()
+    expect(session.type).toBe("progress")
+    expect(session.used).toBe(42)
+    expect(session.limit).toBe(100)
+    expect(session.format).toEqual({ kind: "percent" })
+    expect(session.periodDurationMs).toBe(5 * 60 * 60 * 1000)
+    expect(session.resetsAt).toBe(new Date(1738368000000).toISOString())
+
+    const weekly = result.lines.find((l) => l.label === "Weekly")
+    expect(weekly).toBeTruthy()
+    expect(weekly.type).toBe("progress")
+    expect(weekly.used).toBe(63)
+    expect(weekly.limit).toBe(100)
+    expect(weekly.format).toEqual({ kind: "percent" })
+    expect(weekly.periodDurationMs).toBe(7 * 24 * 60 * 60 * 1000)
     expect(weekly.resetsAt).toBe(new Date(1738972800000).toISOString())
   })
 })


### PR DESCRIPTION
Four upstream provider bug fixes.

- **OpenRouter**: Key Limit now derives `used = limit - limit_remaining` (was reporting lifetime spend); the unlimited case is preserved.
- **Z.ai**: accepts `CREDIT_LIMIT` (renamed from `TOKENS_LIMIT`) with the legacy field kept as a fallback; Session/Weekly windows restored.
- **Copilot**: org-managed `token_based_billing` seats now show Credits from `premium_interactions.credits_used` when meters are empty; the loud-failure path is intact.
- **Cursor**: added `grok-4.6` (in 2.0 / cache_read 0.5 / out 6.0) and `grok-4.6-fast` (in 4.0 / cache_read 1.0 / out 12.0) pricing plus dashed/`-fast`/`Auto` aliases; fixed `grok-4.5-fast` output 18.0 -> 12.0.

Note: the Copilot org-seat field nesting (`premium_interactions.credits_used`) is inferred; a top-level fallback is included. This should be sanity-checked against a live payload before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)