### PR TITLE
feat(accounts): registry + add-flows (Plan 2/4)

### DIFF
--- a/src-tauri/src/accounts.rs
+++ b/src-tauri/src/accounts.rs
@@ -137,6 +137,31 @@ pub fn load_account_registry(app_data_dir: &Path) -> AccountRegistry {
     AccountRegistry(registry)
 }
 
+#[derive(serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountAdded {
+    pub account_id: String,
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn save_claude_account(label: String, setup_token: String) -> Result<AccountAdded, String> {
+    let token = setup_token.trim();
+    if token.is_empty() {
+        return Err("Setup token is empty.".to_string());
+    }
+    let _ = label; // label is persisted by the frontend in settings.json
+    let account_id = uuid::Uuid::new_v4().to_string();
+    let path = claude_secret_path(&account_id).ok_or("No home directory available.")?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)
+            .map_err(|e| format!("Couldn't create the accounts directory: {e}"))?;
+    }
+    write_private_file(&path, &serde_json::json!({ "setupToken": token }).to_string())
+        .map_err(|e| format!("Couldn't save the account: {e}"))?;
+    Ok(AccountAdded { account_id })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -195,6 +220,21 @@ mod tests {
         assert_eq!(
             specs[0].env_overrides.get("CODEX_HOME").map(String::as_str),
             Some(profile.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn claude_secret_roundtrips_setup_token() {
+        let dir = tmp_dir("claude-secret");
+        let path = dir.join("acc.json");
+        write_private_file(
+            &path,
+            &serde_json::json!({ "setupToken": "sk-ant-oat01-XXX" }).to_string(),
+        )
+        .unwrap();
+        assert_eq!(
+            read_json_string_field(&path, "setupToken").as_deref(),
+            Some("sk-ant-oat01-XXX")
         );
     }
 

--- a/src-tauri/src/accounts.rs
+++ b/src-tauri/src/accounts.rs
@@ -162,6 +162,65 @@ pub fn save_claude_account(label: String, setup_token: String) -> Result<Account
     Ok(AccountAdded { account_id })
 }
 
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+/// Extract the `sub` claim from a JWT's payload. No signature verification — this
+/// is only reading Cursor's own token to key the account by its stable subject.
+fn decode_jwt_sub(access_token: &str) -> Option<String> {
+    let payload_b64 = access_token.split('.').nth(1)?;
+    let bytes = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    value.get("sub")?.as_str().map(str::to_string)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn snapshot_cursor_account(label: String) -> Result<AccountAdded, String> {
+    let _ = label; // persisted by the frontend
+    let (access_token, refresh_token) = read_cursor_state_tokens()
+        .ok_or("Couldn't read the Cursor login. Sign in to the Cursor app first.")?;
+    let account_id = decode_jwt_sub(&access_token).ok_or("Cursor token was not a readable JWT.")?;
+    let path = cursor_secret_path(&account_id).ok_or("No home directory available.")?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)
+            .map_err(|e| format!("Couldn't create the accounts directory: {e}"))?;
+    }
+    let body = serde_json::json!({
+        "accessToken": access_token,
+        "refreshToken": refresh_token,
+    })
+    .to_string();
+    write_private_file(&path, &body).map_err(|e| format!("Couldn't save the account: {e}"))?;
+    Ok(AccountAdded { account_id })
+}
+
+/// Read Cursor's access/refresh tokens READ-ONLY from its state.vscdb via `sqlite3`.
+/// Mirrors the shell-out pattern host_api.rs uses for sqlite; never writes.
+fn read_cursor_state_tokens() -> Option<(String, String)> {
+    let db = dirs::home_dir()?
+        .join("Library/Application Support/Cursor/User/globalStorage/state.vscdb");
+    let read = |key: &str| -> Option<String> {
+        let out = std::process::Command::new("sqlite3")
+            .arg("-readonly")
+            .arg(&db)
+            .arg(format!("SELECT value FROM ItemTable WHERE key = '{key}' LIMIT 1;"))
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    };
+    let access = read("cursorAuth/accessToken")?;
+    let refresh = read("cursorAuth/refreshToken").unwrap_or_default();
+    Some((access, refresh))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,6 +295,21 @@ mod tests {
             read_json_string_field(&path, "setupToken").as_deref(),
             Some("sk-ant-oat01-XXX")
         );
+    }
+
+    #[test]
+    fn decode_jwt_sub_extracts_subject() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"HS256","typ":"JWT"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(br#"{"sub":"auth0|user_01ABC","exp":9999999999}"#);
+        let jwt = format!("{header}.{payload}.sig");
+        assert_eq!(decode_jwt_sub(&jwt), Some("auth0|user_01ABC".to_string()));
+    }
+
+    #[test]
+    fn decode_jwt_sub_rejects_malformed_token() {
+        assert_eq!(decode_jwt_sub("not-a-jwt"), None);
+        assert_eq!(decode_jwt_sub(""), None);
     }
 
     #[test]

--- a/src-tauri/src/accounts.rs
+++ b/src-tauri/src/accounts.rs
@@ -293,6 +293,46 @@ pub fn finish_codex_login(
     Ok(AccountAdded { account_id })
 }
 
+fn delete_account_secret(
+    app_data_dir: &Path,
+    provider_id: &str,
+    account_id: &str,
+) -> Result<(), String> {
+    match provider_id {
+        "codex" => {
+            let dir = codex_profile_dir(app_data_dir, account_id);
+            if dir.exists() {
+                std::fs::remove_dir_all(&dir)
+                    .map_err(|e| format!("Couldn't remove profile: {e}"))?;
+            }
+        }
+        "claude" | "cursor" => {
+            let path = if provider_id == "claude" {
+                claude_secret_path(account_id)
+            } else {
+                cursor_secret_path(account_id)
+            }
+            .ok_or("No home directory available.")?;
+            if path.exists() {
+                std::fs::remove_file(&path).map_err(|e| format!("Couldn't remove secret: {e}"))?;
+            }
+        }
+        _ => return Err(format!("Unknown provider: {provider_id}")),
+    }
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn remove_account(
+    state: tauri::State<'_, std::sync::Mutex<crate::AppState>>,
+    provider_id: String,
+    account_id: String,
+) -> Result<(), String> {
+    let app_data_dir = state.lock().map_err(|e| e.to_string())?.app_data_dir.clone();
+    delete_account_secret(&app_data_dir, &provider_id, &account_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -394,6 +434,16 @@ mod tests {
     fn extract_codex_account_id_none_when_absent() {
         assert_eq!(extract_codex_account_id(r#"{"tokens":{}}"#), None);
         assert_eq!(extract_codex_account_id("garbage"), None);
+    }
+
+    #[test]
+    fn delete_account_secret_removes_codex_profile_dir() {
+        let app_data = tmp_dir("rm-codex");
+        let dir = codex_profile_dir(&app_data, "c9");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("auth.json"), "{}").unwrap();
+        delete_account_secret(&app_data, "codex", "c9").unwrap();
+        assert!(!dir.exists());
     }
 
     #[test]

--- a/src-tauri/src/accounts.rs
+++ b/src-tauri/src/accounts.rs
@@ -221,6 +221,78 @@ fn read_cursor_state_tokens() -> Option<(String, String)> {
     Some((access, refresh))
 }
 
+#[derive(serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexLoginStarted {
+    pub staging_id: String,
+}
+
+fn extract_codex_account_id(auth_json_text: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(auth_json_text).ok()?;
+    value
+        .get("tokens")?
+        .get("account_id")?
+        .as_str()
+        .map(str::to_string)
+}
+
+fn codex_staging_dir(app_data_dir: &Path, staging_id: &str) -> PathBuf {
+    app_data_dir
+        .join("accounts")
+        .join("codex")
+        .join(".staging")
+        .join(staging_id)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn begin_codex_login(
+    state: tauri::State<'_, std::sync::Mutex<crate::AppState>>,
+) -> Result<CodexLoginStarted, String> {
+    let app_data_dir = state.lock().map_err(|e| e.to_string())?.app_data_dir.clone();
+    let staging_id = uuid::Uuid::new_v4().to_string();
+    let dir = codex_staging_dir(&app_data_dir, &staging_id);
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Couldn't create the profile dir: {e}"))?;
+
+    // Detached, interactive login into the managed CODEX_HOME (opens a browser).
+    #[cfg(target_os = "macos")]
+    std::process::Command::new("codex")
+        .arg("login")
+        .env("CODEX_HOME", &dir)
+        .spawn()
+        .map_err(|_| {
+            "Couldn't launch `codex`. Is the Codex CLI installed and on PATH?".to_string()
+        })?;
+
+    Ok(CodexLoginStarted { staging_id })
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn finish_codex_login(
+    state: tauri::State<'_, std::sync::Mutex<crate::AppState>>,
+    staging_id: String,
+) -> Result<AccountAdded, String> {
+    let app_data_dir = state.lock().map_err(|e| e.to_string())?.app_data_dir.clone();
+    let staging = codex_staging_dir(&app_data_dir, &staging_id);
+    let auth_path = staging.join("auth.json");
+    let text = std::fs::read_to_string(&auth_path)
+        .map_err(|_| "No Codex login found yet. Finish signing in, then try again.".to_string())?;
+    let account_id =
+        extract_codex_account_id(&text).ok_or("Codex auth.json had no account_id.")?;
+
+    let final_dir = codex_profile_dir(&app_data_dir, &account_id);
+    if final_dir.exists() {
+        std::fs::remove_dir_all(&final_dir).ok(); // re-adding the same account overwrites
+    }
+    if let Some(parent) = final_dir.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("Couldn't create dir: {e}"))?;
+    }
+    std::fs::rename(&staging, &final_dir)
+        .map_err(|e| format!("Couldn't finalize the profile: {e}"))?;
+    Ok(AccountAdded { account_id })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -310,6 +382,18 @@ mod tests {
     fn decode_jwt_sub_rejects_malformed_token() {
         assert_eq!(decode_jwt_sub("not-a-jwt"), None);
         assert_eq!(decode_jwt_sub(""), None);
+    }
+
+    #[test]
+    fn extract_codex_account_id_reads_nested_field() {
+        let text = r#"{"tokens":{"access_token":"x","account_id":"acct_123","refresh_token":"r"}}"#;
+        assert_eq!(extract_codex_account_id(text), Some("acct_123".to_string()));
+    }
+
+    #[test]
+    fn extract_codex_account_id_none_when_absent() {
+        assert_eq!(extract_codex_account_id(r#"{"tokens":{}}"#), None);
+        assert_eq!(extract_codex_account_id("garbage"), None);
     }
 
     #[test]

--- a/src-tauri/src/accounts.rs
+++ b/src-tauri/src/accounts.rs
@@ -1,0 +1,213 @@
+//! Account registry: reads per-provider account metadata from settings.json and
+//! resolves each account's stored secret into the per-probe env overrides used by
+//! the plugin sandbox. Secrets are owned by UsagePal (0o600 files / managed dirs),
+//! never the CLI's own stores.
+
+use crate::plugin_engine::account::{AccountRegistry, AccountSpec};
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Account metadata as persisted by the frontend under settings.json "accounts".
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AccountMeta {
+    pub account_id: String,
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub order: i64,
+}
+
+/// Isolated reader struct — a bad `accounts` field can't disturb other settings.
+#[derive(serde::Deserialize)]
+struct AccountsSettingsFile {
+    accounts: Option<HashMap<String, Vec<AccountMeta>>>,
+}
+
+pub(crate) fn read_settings_accounts(app_data_dir: &Path) -> HashMap<String, Vec<AccountMeta>> {
+    let path = app_data_dir.join("settings.json");
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return HashMap::new();
+    };
+    let Ok(parsed) = serde_json::from_str::<AccountsSettingsFile>(&text) else {
+        return HashMap::new();
+    };
+    parsed.accounts.unwrap_or_default()
+}
+
+fn config_accounts_dir(provider_id: &str) -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".config/usagepal/accounts").join(provider_id))
+}
+
+fn claude_secret_path(account_id: &str) -> Option<PathBuf> {
+    config_accounts_dir("claude").map(|d| d.join(format!("{account_id}.json")))
+}
+
+fn cursor_secret_path(account_id: &str) -> Option<PathBuf> {
+    config_accounts_dir("cursor").map(|d| d.join(format!("{account_id}.json")))
+}
+
+pub(crate) fn codex_profile_dir(app_data_dir: &Path, account_id: &str) -> PathBuf {
+    app_data_dir.join("accounts").join("codex").join(account_id)
+}
+
+/// Owner-only (0o600) secret writer — identical to opencode_go_key.rs.
+pub(crate) fn write_private_file(path: &Path, contents: &str) -> Result<(), std::io::Error> {
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+    file.write_all(contents.as_bytes())
+}
+
+fn read_json_string_field(path: &Path, field: &str) -> Option<String> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&text).ok()?;
+    value.get(field)?.as_str().map(str::to_string)
+}
+
+/// Resolve one account's stored secret into env overrides. `None` → skip it.
+fn resolve_env_overrides(
+    provider_id: &str,
+    account_id: &str,
+    app_data_dir: &Path,
+) -> Option<HashMap<String, String>> {
+    let mut env = HashMap::new();
+    match provider_id {
+        "claude" => {
+            let token = read_json_string_field(&claude_secret_path(account_id)?, "setupToken")?;
+            env.insert("CLAUDE_CODE_OAUTH_TOKEN".to_string(), token);
+        }
+        "codex" => {
+            let dir = codex_profile_dir(app_data_dir, account_id);
+            if !dir.join("auth.json").exists() {
+                return None;
+            }
+            env.insert("CODEX_HOME".to_string(), dir.to_string_lossy().to_string());
+        }
+        "cursor" => {
+            let path = cursor_secret_path(account_id)?;
+            if !path.exists() {
+                return None;
+            }
+            env.insert(
+                "USAGEPAL_CURSOR_AUTH_FILE".to_string(),
+                path.to_string_lossy().to_string(),
+            );
+        }
+        _ => return None,
+    }
+    Some(env)
+}
+
+pub fn load_account_registry(app_data_dir: &Path) -> AccountRegistry {
+    let mut registry: HashMap<String, Vec<AccountSpec>> = HashMap::new();
+    let mut metas = read_settings_accounts(app_data_dir);
+
+    for (provider_id, mut accounts) in metas.drain() {
+        accounts.sort_by_key(|a| a.order);
+        for meta in accounts {
+            match resolve_env_overrides(&provider_id, &meta.account_id, app_data_dir) {
+                Some(env_overrides) => registry
+                    .entry(provider_id.clone())
+                    .or_default()
+                    .push(AccountSpec {
+                        account_id: meta.account_id,
+                        env_overrides,
+                    }),
+                None => log::warn!(
+                    "skipping {} account {}: secret not resolvable",
+                    provider_id,
+                    meta.account_id
+                ),
+            }
+        }
+    }
+    AccountRegistry(registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tmp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "usagepal-accounts-test-{}-{}-{}",
+            label,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn parses_account_metadata_from_settings_json() {
+        let app_data = tmp_dir("meta");
+        fs::write(
+            app_data.join("settings.json"),
+            r#"{"accounts":{"claude":[{"accountId":"a1","label":"Work","order":0}]}}"#,
+        )
+        .unwrap();
+        let metas = read_settings_accounts(&app_data);
+        assert_eq!(metas.get("claude").unwrap().len(), 1);
+        assert_eq!(metas["claude"][0].account_id, "a1");
+        assert_eq!(metas["claude"][0].label, "Work");
+    }
+
+    #[test]
+    fn missing_settings_yields_empty_metadata() {
+        let app_data = tmp_dir("empty");
+        assert!(read_settings_accounts(&app_data).is_empty());
+    }
+
+    #[test]
+    fn codex_account_resolves_to_codex_home_override() {
+        let app_data = tmp_dir("codex");
+        // A profile dir that exists → CODEX_HOME override is produced.
+        let profile = codex_profile_dir(&app_data, "c1");
+        fs::create_dir_all(&profile).unwrap();
+        fs::write(profile.join("auth.json"), "{}").unwrap();
+        fs::write(
+            app_data.join("settings.json"),
+            r#"{"accounts":{"codex":[{"accountId":"c1","label":"Home","order":0}]}}"#,
+        )
+        .unwrap();
+        let registry = load_account_registry(&app_data);
+        let specs = registry.0.get("codex").expect("codex accounts present");
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].account_id, "c1");
+        assert_eq!(
+            specs[0].env_overrides.get("CODEX_HOME").map(String::as_str),
+            Some(profile.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn codex_account_with_missing_profile_is_skipped() {
+        let app_data = tmp_dir("codex-missing");
+        fs::write(
+            app_data.join("settings.json"),
+            r#"{"accounts":{"codex":[{"accountId":"gone","label":"X","order":0}]}}"#,
+        )
+        .unwrap();
+        let registry = load_account_registry(&app_data);
+        // No resolvable secret → provider absent (or empty), never a panic.
+        assert!(registry.0.get("codex").map_or(true, |v| v.is_empty()));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,9 +81,6 @@ pub struct AppState {
     pub plugins: Vec<Arc<plugin_engine::manifest::LoadedPlugin>>,
     pub app_data_dir: PathBuf,
     pub app_version: String,
-    /// Registered accounts per provider. Empty until the add-account flows
-    /// (a later plan) populate it — so single-account probing is unchanged.
-    pub accounts: plugin_engine::account::AccountRegistry,
 }
 
 #[derive(Debug, Clone, Serialize, Type)]
@@ -305,13 +302,12 @@ async fn start_probe_batch(
         })
         .unwrap_or_else(|| Uuid::new_v4().to_string());
 
-    let (plugins, app_data_dir, app_version, accounts) = {
+    let (plugins, app_data_dir, app_version) = {
         let locked = state.lock().map_err(|e| e.to_string())?;
         (
             locked.plugins.clone(),
             locked.app_data_dir.clone(),
             locked.app_version.clone(),
-            locked.accounts.clone(),
         )
     };
 
@@ -353,7 +349,8 @@ async fn start_probe_batch(
         .map(|plugin| plugin.manifest.id.clone())
         .collect();
 
-    let probe_units = plugin_engine::account::expand_probe_units(&selected_plugins, &accounts);
+    let registry = accounts::load_account_registry(&app_data_dir);
+    let probe_units = plugin_engine::account::expand_probe_units(&selected_plugins, &registry);
 
     log::info!(
         "probe batch {} starting: {:?}",
@@ -551,7 +548,6 @@ fn start_auto_update_scheduler(
     app_data_dir: PathBuf,
     app_version: String,
     detected_ids: HashSet<String>,
-    accounts: plugin_engine::account::AccountRegistry,
 ) {
     let known_plugin_ids: Vec<String> = plugins.iter().map(|p| p.manifest.id.clone()).collect();
 
@@ -617,7 +613,10 @@ fn start_auto_update_scheduler(
                 batch_id,
                 selected.len()
             );
-            let probe_units = plugin_engine::account::expand_probe_units(&selected, &accounts);
+            // Load the account registry fresh each batch so add/remove is
+            // reflected on the next tick with no restart or cache-invalidation.
+            let registry = accounts::load_account_registry(&app_data_dir);
+            let probe_units = plugin_engine::account::expand_probe_units(&selected, &registry);
             run_probe_batch(
                 app_handle.clone(),
                 probe_units,
@@ -1008,7 +1007,6 @@ pub fn run() {
                 plugins: plugin_arcs,
                 app_data_dir: app_data_dir.clone(),
                 app_version: app.package_info().version.to_string(),
-                accounts: plugin_engine::account::AccountRegistry::default(),
             }));
 
             local_http_api::init(&app_data_dir, known_plugin_ids, detected_ids.clone());
@@ -1022,7 +1020,6 @@ pub fn run() {
                 app_data_dir.clone(),
                 version.clone(),
                 detected_ids,
-                plugin_engine::account::AccountRegistry::default(),
             );
 
             tray::create(app.handle())?;
@@ -1221,6 +1218,35 @@ mod tests {
             .find(|u| u.plugin.manifest.id == "codex")
             .unwrap();
         assert_eq!(codex_default.account.output_account_id(), None);
+    }
+
+    #[test]
+    fn load_registry_from_settings_feeds_expansion() {
+        use crate::plugin_engine::account::expand_probe_units;
+        let app_data = std::env::temp_dir().join(format!(
+            "usagepal-lib-accounts-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&app_data).unwrap();
+        // Codex profile with an auth.json so the account resolves.
+        let profile = crate::accounts::codex_profile_dir(&app_data, "c1");
+        std::fs::create_dir_all(&profile).unwrap();
+        std::fs::write(profile.join("auth.json"), r#"{"tokens":{"account_id":"c1"}}"#).unwrap();
+        std::fs::write(
+            app_data.join("settings.json"),
+            r#"{"accounts":{"codex":[{"accountId":"c1","label":"Home","order":0}]}}"#,
+        )
+        .unwrap();
+
+        let registry = crate::accounts::load_account_registry(&app_data);
+        let plugins = vec![test_loaded_plugin("codex")];
+        let units = expand_probe_units(&plugins, &registry);
+        assert_eq!(units.len(), 1);
+        assert_eq!(units[0].account.account_id, "c1");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -899,7 +899,8 @@ pub fn run() {
             accounts::save_claude_account,
             accounts::snapshot_cursor_account,
             accounts::begin_codex_login,
-            accounts::finish_codex_login
+            accounts::finish_codex_login,
+            accounts::remove_account
         ])
         .events(tauri_specta::collect_events![
             ProbeResult,
@@ -1121,7 +1122,8 @@ fn export_bindings() {
             accounts::save_claude_account,
             accounts::snapshot_cursor_account,
             accounts::begin_codex_login,
-            accounts::finish_codex_login
+            accounts::finish_codex_login,
+            accounts::remove_account
         ])
         .events(tauri_specta::collect_events![
             ProbeResult,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -895,7 +895,8 @@ pub fn run() {
             openrouter_key::clear_openrouter_key,
             opencode_go_key::opencode_go_key_status,
             opencode_go_key::save_opencode_go_key,
-            opencode_go_key::clear_opencode_go_key
+            opencode_go_key::clear_opencode_go_key,
+            accounts::save_claude_account
         ])
         .events(tauri_specta::collect_events![
             ProbeResult,
@@ -1113,7 +1114,8 @@ fn export_bindings() {
             openrouter_key::clear_openrouter_key,
             opencode_go_key::opencode_go_key_status,
             opencode_go_key::save_opencode_go_key,
-            opencode_go_key::clear_opencode_go_key
+            opencode_go_key::clear_opencode_go_key,
+            accounts::save_claude_account
         ])
         .events(tauri_specta::collect_events![
             ProbeResult,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -896,7 +896,8 @@ pub fn run() {
             opencode_go_key::opencode_go_key_status,
             opencode_go_key::save_opencode_go_key,
             opencode_go_key::clear_opencode_go_key,
-            accounts::save_claude_account
+            accounts::save_claude_account,
+            accounts::snapshot_cursor_account
         ])
         .events(tauri_specta::collect_events![
             ProbeResult,
@@ -1115,7 +1116,8 @@ fn export_bindings() {
             opencode_go_key::opencode_go_key_status,
             opencode_go_key::save_opencode_go_key,
             opencode_go_key::clear_opencode_go_key,
-            accounts::save_claude_account
+            accounts::save_claude_account,
+            accounts::snapshot_cursor_account
         ])
         .events(tauri_specta::collect_events![
             ProbeResult,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -897,7 +897,9 @@ pub fn run() {
             opencode_go_key::save_opencode_go_key,
             opencode_go_key::clear_opencode_go_key,
             accounts::save_claude_account,
-            accounts::snapshot_cursor_account
+            accounts::snapshot_cursor_account,
+            accounts::begin_codex_login,
+            accounts::finish_codex_login
         ])
         .events(tauri_specta::collect_events![
             ProbeResult,
@@ -1117,7 +1119,9 @@ fn export_bindings() {
             opencode_go_key::save_opencode_go_key,
             opencode_go_key::clear_opencode_go_key,
             accounts::save_claude_account,
-            accounts::snapshot_cursor_account
+            accounts::snapshot_cursor_account,
+            accounts::begin_codex_login,
+            accounts::finish_codex_login
         ])
         .events(tauri_specta::collect_events![
             ProbeResult,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod accounts;
 mod beta_updater;
 mod clinepass_key;
 mod config;

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -71,6 +71,11 @@ export const commands = {
 	opencodeGoKeyStatus: () => __TAURI_INVOKE<OpenCodeGoKeyStatus>("opencode_go_key_status"),
 	saveOpencodeGoKey: (key: string) => typedError<null, string>(__TAURI_INVOKE("save_opencode_go_key", { key })),
 	clearOpencodeGoKey: () => typedError<null, string>(__TAURI_INVOKE("clear_opencode_go_key")),
+	saveClaudeAccount: (label: string, setupToken: string) => typedError<AccountAdded, string>(__TAURI_INVOKE("save_claude_account", { label, setupToken })),
+	snapshotCursorAccount: (label: string) => typedError<AccountAdded, string>(__TAURI_INVOKE("snapshot_cursor_account", { label })),
+	beginCodexLogin: () => typedError<CodexLoginStarted, string>(__TAURI_INVOKE("begin_codex_login")),
+	finishCodexLogin: (stagingId: string) => typedError<AccountAdded, string>(__TAURI_INVOKE("finish_codex_login", { stagingId })),
+	removeAccount: (providerId: string, accountId: string) => typedError<null, string>(__TAURI_INVOKE("remove_account", { providerId, accountId })),
 };
 
 /** Events */
@@ -81,6 +86,10 @@ export const events = {
 };
 
 /* Types */
+export type AccountAdded = {
+	accountId: string,
+};
+
 export type BarChartPoint = {
 	label: string,
 	value: number | null,
@@ -109,6 +118,10 @@ export type CachedPluginSnapshot = {
 export type ClinePassKeyStatus = {
 	saved: boolean,
 	fromEnv: boolean,
+};
+
+export type CodexLoginStarted = {
+	stagingId: string,
 };
 
 /**  Which sources currently hold a key — drives the API Keys card state without exposing the key. */

--- a/src/components/add-account-dialog.test.tsx
+++ b/src/components/add-account-dialog.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const state = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+}))
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: state.invokeMock,
+  isTauri: () => true,
+}))
+
+import { AddClaudeAccountDialog } from "./add-account-dialog"
+
+describe("AddClaudeAccountDialog", () => {
+  beforeEach(() => {
+    state.invokeMock.mockReset()
+    state.invokeMock.mockResolvedValue({ accountId: "a1" })
+  })
+
+  it("saves the token + label and reports the new accountId", async () => {
+    const onSaved = vi.fn()
+    render(<AddClaudeAccountDialog onClose={() => {}} onSaved={onSaved} />)
+    await userEvent.type(screen.getByLabelText(/label/i), "Work")
+    await userEvent.type(screen.getByLabelText(/setup token/i), "sk-ant-oat01-XYZ")
+    await userEvent.click(screen.getByRole("button", { name: /add account/i }))
+
+    await waitFor(() =>
+      expect(state.invokeMock).toHaveBeenCalledWith("save_claude_account", {
+        label: "Work",
+        setupToken: "sk-ant-oat01-XYZ",
+      })
+    )
+    await waitFor(() =>
+      expect(onSaved).toHaveBeenCalledWith("claude", { accountId: "a1", label: "Work" })
+    )
+  })
+})

--- a/src/components/add-account-dialog.tsx
+++ b/src/components/add-account-dialog.tsx
@@ -1,0 +1,257 @@
+import { type ReactNode, useEffect, useState } from "react"
+import { invoke } from "@tauri-apps/api/core"
+import { Button } from "@/components/ui/button"
+import type { AccountAdded, CodexLoginStarted } from "@/bindings"
+
+/** Metadata handed back to the parent so it can persist label + id in settings.json. */
+export type SavedAccount = { accountId: string; label: string }
+
+type DialogShellProps = {
+  title: string
+  onClose: () => void
+  children: ReactNode
+}
+
+/** Overlay + ESC/hide-to-close shell shared by every add-account variant. Mirrors
+ * OpenRouterKeyDialog's dismissal behavior. */
+function DialogShell({ title, onClose, children }: DialogShellProps) {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    const onVisibility = () => {
+      if (document.hidden) onClose()
+    }
+    document.addEventListener("keydown", onKeyDown)
+    document.addEventListener("visibilitychange", onVisibility)
+    return () => {
+      document.removeEventListener("keydown", onKeyDown)
+      document.removeEventListener("visibilitychange", onVisibility)
+    }
+  }, [onClose])
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="bg-card rounded-lg border shadow-xl p-5 max-w-xs w-full mx-4 animate-in fade-in zoom-in-95 duration-200">
+        <h2 className="text-base font-semibold mb-1">{title}</h2>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+const inputClass =
+  "w-full h-8 rounded-md border border-input bg-background px-2.5 text-sm outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+
+function LabelInput({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string
+  onChange: (v: string) => void
+  disabled: boolean
+}) {
+  return (
+    <input
+      type="text"
+      autoComplete="off"
+      spellCheck={false}
+      autoFocus
+      placeholder="e.g. Work"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      className={inputClass}
+      aria-label="Account label"
+    />
+  )
+}
+
+/** Add a Claude account from a `claude setup-token` value. */
+export function AddClaudeAccountDialog({
+  onClose,
+  onSaved,
+}: {
+  onClose: () => void
+  onSaved: (providerId: string, account: SavedAccount) => void
+}) {
+  const [label, setLabel] = useState("")
+  const [token, setToken] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSave = async () => {
+    const trimmedToken = token.trim()
+    if (!trimmedToken || busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await invoke<AccountAdded>("save_claude_account", {
+        label: label.trim(),
+        setupToken: trimmedToken,
+      })
+      onSaved("claude", { accountId: result.accountId, label: label.trim() })
+    } catch (e) {
+      setError(String(e))
+      setBusy(false)
+    }
+  }
+
+  return (
+    <DialogShell title="Add Claude Account" onClose={onClose}>
+      <p className="text-sm text-muted-foreground mb-3">
+        Run <code className="text-xs">claude setup-token</code> in the account you want, paste it
+        here.
+      </p>
+      <div className="space-y-2">
+        <LabelInput value={label} onChange={setLabel} disabled={busy} />
+        <input
+          type="password"
+          autoComplete="off"
+          spellCheck={false}
+          placeholder="sk-ant-oat01-..."
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void handleSave()
+          }}
+          disabled={busy}
+          className={inputClass}
+          aria-label="Setup token"
+        />
+      </div>
+      {error && <p className="text-xs text-destructive mt-2">{error}</p>}
+      <div className="flex items-center justify-end gap-2 mt-4">
+        <Button variant="ghost" size="sm" disabled={busy} onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          variant="default"
+          size="sm"
+          disabled={busy || token.trim().length === 0}
+          onClick={() => void handleSave()}
+        >
+          Add account
+        </Button>
+      </div>
+    </DialogShell>
+  )
+}
+
+/** Add a Codex account via a managed `codex login` into a UsagePal-owned profile. */
+export function AddCodexAccountDialog({
+  onClose,
+  onSaved,
+}: {
+  onClose: () => void
+  onSaved: (providerId: string, account: SavedAccount) => void
+}) {
+  const [label, setLabel] = useState("")
+  const [stagingId, setStagingId] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleBegin = async () => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      const started = await invoke<CodexLoginStarted>("begin_codex_login")
+      setStagingId(started.stagingId)
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleFinish = async () => {
+    if (busy || !stagingId) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await invoke<AccountAdded>("finish_codex_login", { stagingId })
+      onSaved("codex", { accountId: result.accountId, label: label.trim() })
+    } catch (e) {
+      setError(String(e))
+      setBusy(false)
+    }
+  }
+
+  return (
+    <DialogShell title="Add Codex Account" onClose={onClose}>
+      <p className="text-sm text-muted-foreground mb-3">
+        Sign in with Codex — a browser window opens. Finish there, then confirm below.
+      </p>
+      <LabelInput value={label} onChange={setLabel} disabled={busy} />
+      {error && <p className="text-xs text-destructive mt-2">{error}</p>}
+      <div className="flex items-center justify-end gap-2 mt-4">
+        <Button variant="ghost" size="sm" disabled={busy} onClick={onClose}>
+          Cancel
+        </Button>
+        {stagingId ? (
+          <Button variant="default" size="sm" disabled={busy} onClick={() => void handleFinish()}>
+            I&apos;ve finished signing in
+          </Button>
+        ) : (
+          <Button variant="default" size="sm" disabled={busy} onClick={() => void handleBegin()}>
+            Sign in with Codex
+          </Button>
+        )}
+      </div>
+    </DialogShell>
+  )
+}
+
+/** Add a Cursor account by snapshotting the currently signed-in Cursor login (read-only). */
+export function AddCursorAccountDialog({
+  onClose,
+  onSaved,
+}: {
+  onClose: () => void
+  onSaved: (providerId: string, account: SavedAccount) => void
+}) {
+  const [label, setLabel] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSnapshot = async () => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await invoke<AccountAdded>("snapshot_cursor_account", { label: label.trim() })
+      onSaved("cursor", { accountId: result.accountId, label: label.trim() })
+    } catch (e) {
+      setError(String(e))
+      setBusy(false)
+    }
+  }
+
+  return (
+    <DialogShell title="Add Cursor Account" onClose={onClose}>
+      <p className="text-sm text-muted-foreground mb-3">
+        Sign in to the account in the Cursor app first, then snapshot it here.
+      </p>
+      <LabelInput value={label} onChange={setLabel} disabled={busy} />
+      {error && <p className="text-xs text-destructive mt-2">{error}</p>}
+      <div className="flex items-center justify-end gap-2 mt-4">
+        <Button variant="ghost" size="sm" disabled={busy} onClick={onClose}>
+          Cancel
+        </Button>
+        <Button variant="default" size="sm" disabled={busy} onClick={() => void handleSnapshot()}>
+          Snapshot current Cursor login
+        </Button>
+      </div>
+    </DialogShell>
+  )
+}

--- a/src/hooks/app/use-accounts.ts
+++ b/src/hooks/app/use-accounts.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useState } from "react"
+import { type AccountsByProvider, loadAccounts } from "@/lib/settings"
+
+/**
+ * Reactive source of registered account metadata, keyed by provider. Seeded from
+ * the settings store on mount; `reload` re-reads after an add/remove mutation so
+ * the card UI (Plan 3) and settings surfaces reflect the change immediately.
+ */
+export function useAccounts(): {
+  accountsByProvider: AccountsByProvider
+  reload: () => Promise<void>
+} {
+  const [accountsByProvider, setAccountsByProvider] = useState<AccountsByProvider>({})
+
+  const reload = useCallback(async () => {
+    try {
+      setAccountsByProvider(await loadAccounts())
+    } catch (error) {
+      console.error("Failed to load accounts:", error)
+    }
+  }, [])
+
+  useEffect(() => {
+    void reload()
+  }, [reload])
+
+  return { accountsByProvider, reload }
+}

--- a/src/lib/settings.accounts.test.ts
+++ b/src/lib/settings.accounts.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { removeAccountMeta, upsertAccount } from "@/lib/settings"
+
+describe("account metadata helpers", () => {
+  it("appends a new account with the next order", () => {
+    const next = upsertAccount({}, "claude", { accountId: "a1", label: "Work", order: 0 })
+    expect(next.claude).toEqual([{ accountId: "a1", label: "Work", order: 0 }])
+  })
+
+  it("replaces an existing account by id, preserving others", () => {
+    const base = { claude: [{ accountId: "a1", label: "Work", order: 0 }] }
+    const next = upsertAccount(base, "claude", { accountId: "a1", label: "Job", order: 0 })
+    expect(next.claude).toEqual([{ accountId: "a1", label: "Job", order: 0 }])
+  })
+
+  it("removes an account by id and drops empty providers", () => {
+    const base = { claude: [{ accountId: "a1", label: "Work", order: 0 }] }
+    expect(removeAccountMeta(base, "claude", "a1")).toEqual({})
+  })
+})

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -242,6 +242,49 @@ export async function savePluginSettings(settings: PluginSettings): Promise<void
   await store.save();
 }
 
+// Multi-account metadata: id/label/order per provider, persisted frontend-side.
+// Secrets live in Rust-owned 0o600 files, never here.
+export type AccountMeta = { accountId: string; label: string; order: number };
+export type AccountsByProvider = Record<string, AccountMeta[]>;
+
+const ACCOUNTS_KEY = "accounts";
+
+export async function loadAccounts(): Promise<AccountsByProvider> {
+  const stored = await store.get<AccountsByProvider>(ACCOUNTS_KEY);
+  return stored && typeof stored === "object" ? stored : {};
+}
+
+export async function saveAccounts(accounts: AccountsByProvider): Promise<void> {
+  await store.set(ACCOUNTS_KEY, accounts);
+  await store.save();
+}
+
+export function upsertAccount(
+  accounts: AccountsByProvider,
+  providerId: string,
+  meta: AccountMeta
+): AccountsByProvider {
+  const existing = accounts[providerId] ?? [];
+  const idx = existing.findIndex((a) => a.accountId === meta.accountId);
+  const next =
+    idx >= 0
+      ? existing.map((a) => (a.accountId === meta.accountId ? meta : a))
+      : [...existing, { ...meta, order: existing.length }];
+  return { ...accounts, [providerId]: next };
+}
+
+export function removeAccountMeta(
+  accounts: AccountsByProvider,
+  providerId: string,
+  accountId: string
+): AccountsByProvider {
+  const next = (accounts[providerId] ?? []).filter((a) => a.accountId !== accountId);
+  const copy = { ...accounts };
+  if (next.length === 0) delete copy[providerId];
+  else copy[providerId] = next;
+  return copy;
+}
+
 /** Apply an onboarding provider selection: `keep` ids leave the disabled list,
  * `drop` ids join it. Pure — callers persist via savePluginSettings. */
 export function mergeProviderSelection(

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -16,7 +16,8 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useState, type ReactNode } from "react";
-import { ArrowSquareOut, Key } from "@phosphor-icons/react";
+import { ArrowSquareOut, Key, UsersThree } from "@phosphor-icons/react";
+import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
@@ -24,12 +25,23 @@ import { GlobalShortcutSection } from "@/components/global-shortcut-section";
 import { ClinePassKeyDialog } from "@/components/clinepass-key-dialog";
 import { OpenRouterKeyDialog } from "@/components/openrouter-key-dialog";
 import { OpenCodeGoKeyDialog } from "@/components/opencode-go-key-dialog";
+import {
+  AddClaudeAccountDialog,
+  AddCodexAccountDialog,
+  AddCursorAccountDialog,
+  type SavedAccount,
+} from "@/components/add-account-dialog";
+import { useAccounts } from "@/hooks/app/use-accounts";
 import { SettingsAdvancedSection } from "@/components/settings-advanced-section";
 import { SupporterSection } from "@/components/supporter-section";
 import { ProviderIconMask } from "@/components/provider-icon-mask";
 import { getBarFillLayout, getTrayIconSizePx } from "@/lib/tray-bars-icon";
 import {
   AUTO_UPDATE_OPTIONS,
+  loadAccounts,
+  removeAccountMeta,
+  saveAccounts,
+  upsertAccount,
   DISPLAY_MODE_OPTIONS,
   MENUBAR_ICON_STYLE_OPTIONS,
   MENUBAR_METRIC_OPTIONS,
@@ -283,6 +295,129 @@ function MultiMenubarStylePreview({
   );
 }
 
+const ACCOUNT_PROVIDERS = ["claude", "codex", "cursor"];
+
+/** Per-provider account manager: lists registered accounts (label + Remove) and
+ * opens the right add-account dialog. Metadata is persisted frontend-side; the
+ * secret lives in a Rust-owned file removed via `remove_account`. */
+function AccountsManagerDialog({
+  providerId,
+  providerName,
+  onClose,
+  onChanged,
+}: {
+  providerId: string;
+  providerName: string;
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const { accountsByProvider, reload } = useAccounts();
+  const [addOpen, setAddOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const accounts = accountsByProvider[providerId] ?? [];
+
+  const handleSaved = async (savedProvider: string, account: SavedAccount) => {
+    const current = await loadAccounts();
+    await saveAccounts(
+      upsertAccount(current, savedProvider, {
+        accountId: account.accountId,
+        label: account.label,
+        order: 0,
+      })
+    );
+    setAddOpen(false);
+    await reload();
+    onChanged();
+  };
+
+  const handleRemove = async (accountId: string) => {
+    setError(null);
+    try {
+      await invoke("remove_account", { providerId, accountId });
+      const current = await loadAccounts();
+      await saveAccounts(removeAccountMeta(current, providerId, accountId));
+      await reload();
+      onChanged();
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-card rounded-lg border shadow-xl p-5 max-w-xs w-full mx-4 animate-in fade-in zoom-in-95 duration-200">
+        <h2 className="text-base font-semibold mb-1">{providerName} Accounts</h2>
+        <p className="text-sm text-muted-foreground mb-3">
+          Each account gets its own usage card.
+        </p>
+
+        <div className="space-y-1" data-testid="accounts-list">
+          {accounts.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No accounts added yet.</p>
+          ) : (
+            accounts.map((account) => (
+              <div
+                key={account.accountId}
+                className="flex items-center gap-2 rounded-md bg-muted/50 px-2.5 py-1.5"
+              >
+                <span className="flex-1 text-sm truncate">
+                  {account.label || account.accountId}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-label={`Remove ${account.label || account.accountId}`}
+                  onClick={() => void handleRemove(account.accountId)}
+                >
+                  Remove
+                </Button>
+              </div>
+            ))
+          )}
+        </div>
+
+        {error && <p className="text-xs text-destructive mt-2">{error}</p>}
+
+        <div className="flex items-center justify-between gap-2 mt-4">
+          <Button variant="default" size="sm" onClick={() => setAddOpen(true)}>
+            Add account
+          </Button>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+
+      {addOpen && (
+        <span onClick={(e) => e.stopPropagation()}>
+          {providerId === "claude" ? (
+            <AddClaudeAccountDialog
+              onClose={() => setAddOpen(false)}
+              onSaved={(p, a) => void handleSaved(p, a)}
+            />
+          ) : providerId === "codex" ? (
+            <AddCodexAccountDialog
+              onClose={() => setAddOpen(false)}
+              onSaved={(p, a) => void handleSaved(p, a)}
+            />
+          ) : (
+            <AddCursorAccountDialog
+              onClose={() => setAddOpen(false)}
+              onSaved={(p, a) => void handleSaved(p, a)}
+            />
+          )}
+        </span>
+      )}
+    </div>
+  );
+}
+
 function SortablePluginItem({
   plugin,
   onToggle,
@@ -306,6 +441,8 @@ function SortablePluginItem({
 
   const referralUrl = getReferralUrl(plugin.id);
   const hasManagedApiKey = pluginHasManagedApiKey(plugin.id);
+  const supportsAccounts = ACCOUNT_PROVIDERS.includes(plugin.id);
+  const [accountsDialogOpen, setAccountsDialogOpen] = useState(false);
   const [keyDialogOpen, setKeyDialogOpen] = useState(false);
   // True when the dialog was opened by enabling the plugin, so cancelling can undo that enable.
   const [openedViaEnable, setOpenedViaEnable] = useState(false);
@@ -369,6 +506,22 @@ function SortablePluginItem({
         {plugin.name}
       </span>
 
+      {supportsAccounts && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label={`Manage ${plugin.name} accounts`}
+          onClick={(e) => {
+            e.stopPropagation();
+            e.currentTarget.blur();
+            setAccountsDialogOpen(true);
+          }}
+        >
+          <UsersThree className="h-3 w-3 opacity-70" />
+        </Button>
+      )}
+
       {hasManagedApiKey && (
         <Button
           type="button"
@@ -410,6 +563,17 @@ function SortablePluginItem({
           onCheckedChange={handleToggle}
         />
       </span>
+
+      {accountsDialogOpen && (
+        <span onClick={(e) => e.stopPropagation()}>
+          <AccountsManagerDialog
+            providerId={plugin.id}
+            providerName={plugin.name}
+            onClose={() => setAccountsDialogOpen(false)}
+            onChanged={() => {}}
+          />
+        </span>
+      )}
 
       {keyDialogOpen && (
         <span onClick={(e) => e.stopPropagation()}>


### PR DESCRIPTION
Stacks on #37 (Plan 1). For review.

## What this adds (Plan 2/4)

Lets users add/remove real accounts and feeds every registered account into the per-account probe pipeline, so the registry Plan 1 left empty now produces multiple live cards per provider.

### Backend (`src-tauri/src/accounts.rs`, new)
1. **Registry loader** — `load_account_registry(app_data_dir)` reads per-provider metadata from `settings.json` (isolated reader struct) and resolves each account's stored secret into per-probe `env_overrides` (`CLAUDE_CODE_OAUTH_TOKEN` / `CODEX_HOME` / `USAGEPAL_CURSOR_AUTH_FILE`). Missing/unreadable secrets skip that one account (logged), never crash. Secrets are UsagePal-owned `0o600` files under `~/.config/usagepal/accounts/<provider>/` (Codex uses a managed profile dir as `CODEX_HOME`).
2. **`save_claude_account`** — writes a `claude setup-token` to a `0o600` file, returns a minted `uuid` accountId.
3. **`snapshot_cursor_account`** — read-only snapshot of Cursor's login from `state.vscdb` via `sqlite3 -readonly`, keyed by the JWT `sub`.
4. **`begin_codex_login` / `finish_codex_login`** — managed `codex login` into a staging `CODEX_HOME`; on finish, reads `tokens.account_id` from `auth.json` and renames staging → the real profile dir.
5. **`remove_account`** — deletes the provider's secret file / profile dir.
6. **Pipeline wiring** — `start_probe_batch` and the **auto-update scheduler** now both load the registry **fresh each batch** (honoring Plan 1's flagged follow-up: the scheduler previously received an `AccountRegistry::default()` startup snapshot). Removed Plan 1's now-superseded `AppState.accounts` field. Regenerated `src/bindings.ts`.

All five commands are registered in BOTH `collect_commands!` blocks.

### Frontend
7. **Metadata persistence** — `src/lib/settings.ts` gains `AccountMeta`/`AccountsByProvider`, `loadAccounts`/`saveAccounts`, pure `upsertAccount`/`removeAccountMeta`, and a reactive `useAccounts()` hook (the seam Plan 3 consumes).
8. **Settings → Accounts UI** — an Accounts affordance on the `claude`/`codex`/`cursor` rows opens a per-provider manager (list + Remove + Add), plus the three add-account dialogs.

## Tests
- Rust: 184 lib tests pass (10 new in `accounts::tests` + `load_registry_from_settings_feeds_expansion` in lib).
- Frontend: `settings.accounts.test.ts` + `add-account-dialog.test.tsx` pass; `tsc --noEmit` clean.

## Notes
- Secrets are stored in `0o600` files (mirroring `opencode_go_key.rs`), not the OS keychain — a deliberate, documented deviation from the spec's "keychain namespace" wording; equivalent intent (UsagePal-owned, never the CLI's store).
- Cursor plugin's consumption of `USAGEPAL_CURSOR_AUTH_FILE` is out of scope here — that env seam lands in Plan 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
