### PR TITLE
feat(accounts): Cursor per-account read-only seam (Plan 4/4)

### DIFF
--- a/plugins/cursor/plugin.js
+++ b/plugins/cursor/plugin.js
@@ -19,6 +19,12 @@
   // real state.vscdb / keychain. See docs/superpowers plan "multi-account-cursor-seam".
   const MANAGED_AUTH_ENV = "USAGEPAL_CURSOR_AUTH_FILE"
 
+  // Cursor's /oauth/token has not been verified to rotate the refresh token.
+  // Managed refresh stays enabled but captures any rotated refresh_token so the
+  // UsagePal snapshot never diverges from the server. Flip to false to fall back
+  // to read-only + stale if verification shows rotation breaks the real Cursor app.
+  const MANAGED_REFRESH_ALLOWED = true
+
   const MAX_MODE_UPLIFT = 1.2
 
   // Per-million USD token rates, synced from https://cursor.com/docs/models-and-pricing.md.
@@ -757,20 +763,25 @@
     return subject || null
   }
 
+  function persistManagedAuth(ctx, managedPath, accessToken, refreshToken) {
+    // Read-only toward Cursor: keep the refreshed tokens in UsagePal's own
+    // snapshot file, never Cursor's state.vscdb or keychain.
+    if (!managedPath || !ctx.host.fs || typeof ctx.host.fs.writeText !== "function") return false
+    try {
+      const existing = ctx.util.tryParseJson(ctx.host.fs.readText(managedPath)) || {}
+      const next = { ...existing, accessToken }
+      if (typeof refreshToken === "string" && refreshToken) next.refreshToken = refreshToken
+      ctx.host.fs.writeText(managedPath, JSON.stringify(next))
+      return true
+    } catch (e) {
+      ctx.host.log.warn("managed cursor token persist failed for " + managedPath + ": " + String(e))
+      return false
+    }
+  }
+
   function persistAccessToken(ctx, source, accessToken, managedPath) {
     if (source === "managed") {
-      // Read-only toward Cursor: keep the refreshed token in UsagePal's own
-      // snapshot file, never Cursor's state.vscdb or keychain.
-      if (!managedPath || !ctx.host.fs || typeof ctx.host.fs.writeText !== "function") return false
-      try {
-        const existing = ctx.util.tryParseJson(ctx.host.fs.readText(managedPath)) || {}
-        const next = { ...existing, accessToken }
-        ctx.host.fs.writeText(managedPath, JSON.stringify(next))
-        return true
-      } catch (e) {
-        ctx.host.log.warn("managed cursor token persist failed for " + managedPath + ": " + String(e))
-        return false
-      }
+      return persistManagedAuth(ctx, managedPath, accessToken, undefined)
     }
     if (source === "keychain") {
       return writeKeychainValue(ctx, KEYCHAIN_ACCESS_TOKEN_SERVICE, accessToken)
@@ -795,6 +806,13 @@
   }
 
   function refreshToken(ctx, refreshTokenValue, source, managedPath) {
+    if (source === "managed" && !MANAGED_REFRESH_ALLOWED) {
+      // Safe fallback: never rotate a managed account's tokens against the live
+      // endpoint. Probe renders last-known / stale data ("re-snapshot") instead.
+      ctx.host.log.info("managed cursor refresh disabled; staying read-only + stale")
+      return null
+    }
+
     if (!refreshTokenValue) {
       ctx.host.log.warn("refresh skipped: no refresh token")
       return null
@@ -849,7 +867,13 @@
       }
 
       // Persist updated access token to source where auth was loaded from.
-      persistAccessToken(ctx, source, newAccessToken, managedPath)
+      // For managed accounts, also capture any rotated refresh token so the
+      // UsagePal snapshot never diverges from the server.
+      if (source === "managed") {
+        persistManagedAuth(ctx, managedPath, newAccessToken, body.refresh_token)
+      } else {
+        persistAccessToken(ctx, source, newAccessToken, managedPath)
+      }
       ctx.host.log.info("refresh succeeded, token persisted")
 
       // Note: Cursor refresh returns access_token which is used as both

--- a/plugins/cursor/plugin.js
+++ b/plugins/cursor/plugin.js
@@ -14,6 +14,11 @@
   const REFRESH_BUFFER_MS = 5 * 60 * 1000 // refresh 5 minutes before expiration
   const LOGIN_HINT = "Sign in via Cursor app or run `agent login`."
 
+  // UsagePal multi-account seam: when this env var points at a snapshot JSON
+  // file, the plugin probes that managed account read-only instead of Cursor's
+  // real state.vscdb / keychain. See docs/superpowers plan "multi-account-cursor-seam".
+  const MANAGED_AUTH_ENV = "USAGEPAL_CURSOR_AUTH_FILE"
+
   const MAX_MODE_UPLIFT = 1.2
 
   // Per-million USD token rates, synced from https://cursor.com/docs/models-and-pricing.md.
@@ -659,7 +664,44 @@
     }
   }
 
+  function readManagedAuth(ctx) {
+    if (!ctx.host.env || typeof ctx.host.env.get !== "function") return null
+    if (!ctx.host.fs || typeof ctx.host.fs.readText !== "function") return null
+    let path = null
+    try {
+      path = ctx.host.env.get(MANAGED_AUTH_ENV)
+    } catch (e) {
+      ctx.host.log.warn(MANAGED_AUTH_ENV + " read failed: " + String(e))
+      return null
+    }
+    if (typeof path !== "string" || !path.trim()) return null
+    path = path.trim()
+    try {
+      const text = ctx.host.fs.readText(path)
+      const parsed = ctx.util.tryParseJson(text)
+      if (!parsed || typeof parsed.accessToken !== "string" || !parsed.accessToken) {
+        ctx.host.log.warn("managed cursor auth file missing accessToken: " + path)
+        return null
+      }
+      return {
+        accessToken: parsed.accessToken,
+        refreshToken: typeof parsed.refreshToken === "string" ? parsed.refreshToken : null,
+        source: "managed",
+        managedPath: path,
+      }
+    } catch (e) {
+      ctx.host.log.warn("managed cursor auth read failed for " + path + ": " + String(e))
+      return null
+    }
+  }
+
   function loadAuthState(ctx) {
+    const managed = readManagedAuth(ctx)
+    if (managed) {
+      ctx.host.log.info("using managed cursor account snapshot")
+      return managed
+    }
+
     const sqliteAccessToken = readStateValue(ctx, "cursorAuth/accessToken")
     const sqliteRefreshToken = readStateValue(ctx, "cursorAuth/refreshToken")
     const sqliteMembershipTypeRaw = readStateValue(ctx, "cursorAuth/stripeMembershipType")

--- a/plugins/cursor/plugin.js
+++ b/plugins/cursor/plugin.js
@@ -757,7 +757,21 @@
     return subject || null
   }
 
-  function persistAccessToken(ctx, source, accessToken) {
+  function persistAccessToken(ctx, source, accessToken, managedPath) {
+    if (source === "managed") {
+      // Read-only toward Cursor: keep the refreshed token in UsagePal's own
+      // snapshot file, never Cursor's state.vscdb or keychain.
+      if (!managedPath || !ctx.host.fs || typeof ctx.host.fs.writeText !== "function") return false
+      try {
+        const existing = ctx.util.tryParseJson(ctx.host.fs.readText(managedPath)) || {}
+        const next = { ...existing, accessToken }
+        ctx.host.fs.writeText(managedPath, JSON.stringify(next))
+        return true
+      } catch (e) {
+        ctx.host.log.warn("managed cursor token persist failed for " + managedPath + ": " + String(e))
+        return false
+      }
+    }
     if (source === "keychain") {
       return writeKeychainValue(ctx, KEYCHAIN_ACCESS_TOKEN_SERVICE, accessToken)
     }
@@ -780,7 +794,7 @@
     })
   }
 
-  function refreshToken(ctx, refreshTokenValue, source) {
+  function refreshToken(ctx, refreshTokenValue, source, managedPath) {
     if (!refreshTokenValue) {
       ctx.host.log.warn("refresh skipped: no refresh token")
       return null
@@ -835,7 +849,7 @@
       }
 
       // Persist updated access token to source where auth was loaded from.
-      persistAccessToken(ctx, source, newAccessToken)
+      persistAccessToken(ctx, source, newAccessToken, managedPath)
       ctx.host.log.info("refresh succeeded, token persisted")
 
       // Note: Cursor refresh returns access_token which is used as both
@@ -1003,6 +1017,7 @@
     let accessToken = authState.accessToken
     const refreshTokenValue = authState.refreshToken
     const authSource = authState.source
+    const managedPath = authState.managedPath
 
     if (!accessToken && !refreshTokenValue) {
       ctx.host.log.error("probe failed: no access or refresh token in sqlite/keychain")
@@ -1018,7 +1033,7 @@
       ctx.host.log.info("token needs refresh (expired or expiring soon)")
       let refreshed = null
       try {
-        refreshed = refreshToken(ctx, refreshTokenValue, authSource)
+        refreshed = refreshToken(ctx, refreshTokenValue, authSource, managedPath)
       } catch (e) {
         // If refresh fails but we have an access token, try it anyway
         ctx.host.log.warn("refresh failed but have access token, will try: " + String(e))
@@ -1050,7 +1065,7 @@
         refresh: () => {
           ctx.host.log.info("usage returned 401, attempting refresh")
           didRefresh = true
-          const refreshed = refreshToken(ctx, refreshTokenValue, authSource)
+          const refreshed = refreshToken(ctx, refreshTokenValue, authSource, managedPath)
           if (refreshed) accessToken = refreshed
           return refreshed
         },

--- a/plugins/cursor/plugin.multi-account.test.js
+++ b/plugins/cursor/plugin.multi-account.test.js
@@ -62,4 +62,37 @@ describe("cursor plugin — managed account seam", () => {
 
     expect(ctx.host.sqlite.query).toHaveBeenCalled() // existing path is intact
   })
+
+  it("refreshes a managed account without touching Cursor's stores", async () => {
+    const ctx = makeCtx()
+    const expiredToken = makeJwt({ sub: "auth0|user123", exp: 1 }) // 1970 → needs refresh
+    const refreshedToken = makeJwt({ sub: "auth0|user123", exp: 4102444800 })
+    ctx.host.env.get.mockImplementation((name) =>
+      name === "USAGEPAL_CURSOR_AUTH_FILE" ? MANAGED_PATH : null
+    )
+    ctx.host.fs.writeText(
+      MANAGED_PATH,
+      JSON.stringify({ accessToken: expiredToken, refreshToken: "managed-refresh" })
+    )
+    ctx.host.fs.writeText.mockClear()
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("oauth/token")) {
+        return { status: 200, headers: {}, bodyText: JSON.stringify({ access_token: refreshedToken }) }
+      }
+      return { status: 200, headers: {}, bodyText: "{}" }
+    })
+
+    const plugin = await loadPlugin()
+    try { plugin.probe(ctx) } catch (_e) { /* usage parsing out of scope */ }
+
+    // Cursor's own stores are never written.
+    expect(ctx.host.sqlite.exec).not.toHaveBeenCalled()
+    expect(ctx.host.keychain.writeGenericPassword).not.toHaveBeenCalled()
+    // The refreshed token is persisted ONLY to the managed snapshot file.
+    const managedWrites = ctx.host.fs.writeText.mock.calls.filter((c) => c[0] === MANAGED_PATH)
+    expect(managedWrites.length).toBeGreaterThan(0)
+    const lastWrite = JSON.parse(managedWrites[managedWrites.length - 1][1])
+    expect(lastWrite.accessToken).toBe(refreshedToken)
+    expect(lastWrite.refreshToken).toBe("managed-refresh")
+  })
 })

--- a/plugins/cursor/plugin.multi-account.test.js
+++ b/plugins/cursor/plugin.multi-account.test.js
@@ -95,4 +95,35 @@ describe("cursor plugin — managed account seam", () => {
     expect(lastWrite.accessToken).toBe(refreshedToken)
     expect(lastWrite.refreshToken).toBe("managed-refresh")
   })
+
+  it("captures a rotated refresh token into the managed snapshot", async () => {
+    const ctx = makeCtx()
+    const expiredToken = makeJwt({ sub: "auth0|user123", exp: 1 })
+    const refreshedToken = makeJwt({ sub: "auth0|user123", exp: 4102444800 })
+    ctx.host.env.get.mockImplementation((name) =>
+      name === "USAGEPAL_CURSOR_AUTH_FILE" ? MANAGED_PATH : null
+    )
+    ctx.host.fs.writeText(
+      MANAGED_PATH,
+      JSON.stringify({ accessToken: expiredToken, refreshToken: "old-refresh" })
+    )
+    ctx.host.fs.writeText.mockClear()
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("oauth/token")) {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({ access_token: refreshedToken, refresh_token: "rotated-refresh" }),
+        }
+      }
+      return { status: 200, headers: {}, bodyText: "{}" }
+    })
+
+    const plugin = await loadPlugin()
+    try { plugin.probe(ctx) } catch (_e) {}
+
+    const managedWrites = ctx.host.fs.writeText.mock.calls.filter((c) => c[0] === MANAGED_PATH)
+    const lastWrite = JSON.parse(managedWrites[managedWrites.length - 1][1])
+    expect(lastWrite.refreshToken).toBe("rotated-refresh") // captured, not left stale
+  })
 })

--- a/plugins/cursor/plugin.multi-account.test.js
+++ b/plugins/cursor/plugin.multi-account.test.js
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { makeCtx } from "../test-helpers.js"
+
+const loadPlugin = async () => {
+  await import("./plugin.js")
+  return globalThis.__openusage_plugin
+}
+
+const makeJwt = (payload) => [
+  Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+  Buffer.from(JSON.stringify(payload)).toString("base64url"),
+  "signature",
+].join(".")
+
+const MANAGED_PATH = "~/.config/usagepal/accounts/cursor/user123.json"
+
+describe("cursor plugin — managed account seam", () => {
+  beforeEach(() => {
+    delete globalThis.__openusage_plugin
+    vi.resetModules()
+  })
+
+  it("uses the managed snapshot and never reads Cursor's own stores", async () => {
+    const ctx = makeCtx()
+    const managedToken = makeJwt({ sub: "auth0|user123", exp: 4102444800 }) // year 2100
+    ctx.host.env.get.mockImplementation((name) =>
+      name === "USAGEPAL_CURSOR_AUTH_FILE" ? MANAGED_PATH : null
+    )
+    ctx.host.fs.writeText(
+      MANAGED_PATH,
+      JSON.stringify({ accessToken: managedToken, refreshToken: "managed-refresh" })
+    )
+    ctx.host.fs.writeText.mockClear() // ignore the test's own seed write
+    ctx.host.http.request.mockReturnValue({ status: 200, headers: {}, bodyText: "{}" })
+
+    const plugin = await loadPlugin()
+    try { plugin.probe(ctx) } catch (_e) { /* downstream usage parsing is out of scope */ }
+
+    // Managed token was used for the API call...
+    const authHeaders = ctx.host.http.request.mock.calls
+      .map((c) => c[0]?.headers?.Authorization)
+      .filter(Boolean)
+    expect(authHeaders).toContain("Bearer " + managedToken)
+    // ...and Cursor's own credential stores were never read.
+    expect(ctx.host.sqlite.query).not.toHaveBeenCalled()
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
+  })
+
+  it("falls back to Cursor's sqlite store when no managed env var is set", async () => {
+    const ctx = makeCtx()
+    const sqliteToken = makeJwt({ sub: "auth0|local", exp: 4102444800 })
+    ctx.host.env.get.mockReturnValue(null)
+    ctx.host.sqlite.query.mockImplementation((_db, sql) => {
+      if (sql.includes("cursorAuth/accessToken")) return JSON.stringify([{ value: sqliteToken }])
+      if (sql.includes("cursorAuth/refreshToken")) return JSON.stringify([{ value: "local-refresh" }])
+      return "[]"
+    })
+    ctx.host.http.request.mockReturnValue({ status: 200, headers: {}, bodyText: "{}" })
+
+    const plugin = await loadPlugin()
+    try { plugin.probe(ctx) } catch (_e) { /* usage parsing out of scope */ }
+
+    expect(ctx.host.sqlite.query).toHaveBeenCalled() // existing path is intact
+  })
+})


### PR DESCRIPTION
## Cursor per-account read-only seam

Adds a **"managed"** credential source to `plugins/cursor/plugin.js` so UsagePal can probe a snapshotted Cursor account read-only, selected by an injected env var, without ever writing back to Cursor's real `state.vscdb` or keychain.

Stacks on the Plan 2 PR (`feat/multi-account-registry`), which provides the `USAGEPAL_CURSOR_AUTH_FILE` env contract and the snapshot-file writer. Base is set to that branch.

### Tasks

1. **Managed-source branch in `loadAuthState`** — new `MANAGED_AUTH_ENV` constant + `readManagedAuth(ctx)` helper (host `env`/`fs` capability-guarded like codex's `readCodexHome`). When `USAGEPAL_CURSOR_AUTH_FILE` is present, `loadAuthState` reads that JSON snapshot via `ctx.host.fs` and returns `{ accessToken, refreshToken, source: "managed", managedPath }`, short-circuiting the sqlite/keychain reads. Env absent → the sqlite/keychain path is byte-for-byte unchanged.

2. **Non-destructive `persistAccessToken` for managed accounts** — for `source === "managed"`, refreshed tokens are written only to the managed snapshot file, never `writeStateValue` (sqlite) or `writeKeychainValue`. `managedPath` is threaded from the loaded auth object through both `refreshToken` call sites in `probe`. Non-managed keychain/sqlite write-back is unchanged.

3. **Refresh-rotation safety gate** — `MANAGED_REFRESH_ALLOWED` flag (default `true`). Managed refresh stays enabled but now captures any rotated `refresh_token` from the response into the managed file so the snapshot never diverges from the server. If live verification later shows Cursor rotates+invalidates the refresh token in a way that logs the real app out, flip the flag to `false` for a read-only + stale ("re-snapshot") fallback.

### Hard constraint

Read-only toward Cursor's real `state.vscdb` / keychain — enforced by tests asserting `sqlite.query`/`keychain.readGenericPassword` are never called on the managed path, and `sqlite.exec`/`keychain.writeGenericPassword` are never called on managed refresh.

### Tests

New `plugins/cursor/plugin.multi-account.test.js` (4 tests, mirroring the codex harness). Full `plugins/cursor` suite green (86 tests).

### Follow-up

Task 3 Step 5 is an out-of-band empirical check against Cursor's live `/oauth/token` (snapshot a real login, let UsagePal refresh, confirm the real Cursor app still refreshes). Not runnable in CI/this environment — pending. Safe default (`true` + rotated-token capture) is in place; record the finding in spec §11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)