### PR TITLE
feat(accounts): per-provider account cards UI (Plan 3/4)

### DIFF
--- a/src-tauri/src/accounts.rs
+++ b/src-tauri/src/accounts.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use tauri::Emitter;
 
 /// Account metadata as persisted by the frontend under settings.json "accounts".
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -244,10 +245,50 @@ fn codex_staging_dir(app_data_dir: &Path, staging_id: &str) -> PathBuf {
         .join(staging_id)
 }
 
+/// Event payload emitted when a Codex login finishes on its own (the watcher
+/// below), so the UI completes without a button the tray panel would hide.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexLoginComplete {
+    account_id: String,
+    label: String,
+}
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexLoginFailed {
+    message: String,
+}
+
+/// Move a completed staging login into its final per-account profile dir and
+/// return the resolved account id. Shared by the auto-watcher and the manual
+/// `finish_codex_login` fallback.
+fn finalize_codex_login(app_data_dir: &Path, staging_id: &str) -> Result<String, String> {
+    let staging = codex_staging_dir(app_data_dir, staging_id);
+    let auth_path = staging.join("auth.json");
+    let text = std::fs::read_to_string(&auth_path)
+        .map_err(|_| "No Codex login found yet. Finish signing in, then try again.".to_string())?;
+    let account_id =
+        extract_codex_account_id(&text).ok_or("Codex auth.json had no account_id.")?;
+
+    let final_dir = codex_profile_dir(app_data_dir, &account_id);
+    if final_dir.exists() {
+        std::fs::remove_dir_all(&final_dir).ok(); // re-adding the same account overwrites
+    }
+    if let Some(parent) = final_dir.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("Couldn't create dir: {e}"))?;
+    }
+    std::fs::rename(&staging, &final_dir)
+        .map_err(|e| format!("Couldn't finalize the profile: {e}"))?;
+    Ok(account_id)
+}
+
 #[tauri::command]
 #[specta::specta]
 pub fn begin_codex_login(
+    app: tauri::AppHandle,
     state: tauri::State<'_, std::sync::Mutex<crate::AppState>>,
+    label: String,
 ) -> Result<CodexLoginStarted, String> {
     let app_data_dir = state.lock().map_err(|e| e.to_string())?.app_data_dir.clone();
     let staging_id = uuid::Uuid::new_v4().to_string();
@@ -255,14 +296,65 @@ pub fn begin_codex_login(
     std::fs::create_dir_all(&dir).map_err(|e| format!("Couldn't create the profile dir: {e}"))?;
 
     // Detached, interactive login into the managed CODEX_HOME (opens a browser).
+    // A Finder/Dock launch inherits a minimal PATH (no Homebrew/npm), so resolve
+    // the user's real login-shell PATH the way the usage plugins do — otherwise
+    // `codex` isn't found even when it's installed.
     #[cfg(target_os = "macos")]
-    std::process::Command::new("codex")
-        .arg("login")
-        .env("CODEX_HOME", &dir)
-        .spawn()
-        .map_err(|_| {
-            "Couldn't launch `codex`. Is the Codex CLI installed and on PATH?".to_string()
+    {
+        let mut cmd = std::process::Command::new("codex");
+        cmd.arg("login").env("CODEX_HOME", &dir);
+        if let Some(path) = crate::plugin_engine::host_api::read_env_from_interactive_shells("PATH")
+        {
+            cmd.env("PATH", path);
+        }
+        cmd.spawn().map_err(|_| {
+            "Couldn't launch `codex`. Is the Codex CLI installed? (npm i -g @openai/codex)"
+                .to_string()
         })?;
+    }
+
+    // Watch the staging dir and finalize on our own, so completion never depends
+    // on the tray panel staying open (it hides the moment the browser takes
+    // focus). Emits `codex:login-complete` / `codex:login-failed` for the UI.
+    let watch_dir = app_data_dir.clone();
+    let watch_staging = staging_id.clone();
+    std::thread::spawn(move || {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(300);
+        loop {
+            std::thread::sleep(std::time::Duration::from_secs(2));
+            let auth = codex_staging_dir(&watch_dir, &watch_staging).join("auth.json");
+            // Only act once auth.json exists AND carries an account_id — codex may
+            // create the file a moment before it finishes writing the tokens.
+            if auth.exists()
+                && std::fs::read_to_string(&auth)
+                    .ok()
+                    .and_then(|t| extract_codex_account_id(&t))
+                    .is_some()
+            {
+                match finalize_codex_login(&watch_dir, &watch_staging) {
+                    Ok(account_id) => {
+                        let _ = app.emit(
+                            "codex:login-complete",
+                            CodexLoginComplete { account_id, label },
+                        );
+                    }
+                    Err(message) => {
+                        let _ = app.emit("codex:login-failed", CodexLoginFailed { message });
+                    }
+                }
+                return;
+            }
+            if std::time::Instant::now() >= deadline {
+                let _ = app.emit(
+                    "codex:login-failed",
+                    CodexLoginFailed {
+                        message: "Timed out waiting for the Codex sign-in to finish.".to_string(),
+                    },
+                );
+                return;
+            }
+        }
+    });
 
     Ok(CodexLoginStarted { staging_id })
 }
@@ -274,22 +366,7 @@ pub fn finish_codex_login(
     staging_id: String,
 ) -> Result<AccountAdded, String> {
     let app_data_dir = state.lock().map_err(|e| e.to_string())?.app_data_dir.clone();
-    let staging = codex_staging_dir(&app_data_dir, &staging_id);
-    let auth_path = staging.join("auth.json");
-    let text = std::fs::read_to_string(&auth_path)
-        .map_err(|_| "No Codex login found yet. Finish signing in, then try again.".to_string())?;
-    let account_id =
-        extract_codex_account_id(&text).ok_or("Codex auth.json had no account_id.")?;
-
-    let final_dir = codex_profile_dir(&app_data_dir, &account_id);
-    if final_dir.exists() {
-        std::fs::remove_dir_all(&final_dir).ok(); // re-adding the same account overwrites
-    }
-    if let Some(parent) = final_dir.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("Couldn't create dir: {e}"))?;
-    }
-    std::fs::rename(&staging, &final_dir)
-        .map_err(|e| format!("Couldn't finalize the profile: {e}"))?;
+    let account_id = finalize_codex_login(&app_data_dir, &staging_id)?;
     Ok(AccountAdded { account_id })
 }
 
@@ -434,6 +511,33 @@ mod tests {
     fn extract_codex_account_id_none_when_absent() {
         assert_eq!(extract_codex_account_id(r#"{"tokens":{}}"#), None);
         assert_eq!(extract_codex_account_id("garbage"), None);
+    }
+
+    #[test]
+    fn finalize_codex_login_moves_staging_into_profile_dir() {
+        let app_data = tmp_dir("finalize");
+        let staging_id = "stg-1";
+        let staging = codex_staging_dir(&app_data, staging_id);
+        fs::create_dir_all(&staging).unwrap();
+        fs::write(
+            staging.join("auth.json"),
+            r#"{"tokens":{"account_id":"acct_final"}}"#,
+        )
+        .unwrap();
+
+        let account_id = finalize_codex_login(&app_data, staging_id).unwrap();
+        assert_eq!(account_id, "acct_final");
+
+        // Staging is consumed; the profile dir now holds the auth.json.
+        assert!(!staging.exists());
+        let profile = codex_profile_dir(&app_data, "acct_final");
+        assert!(profile.join("auth.json").exists());
+    }
+
+    #[test]
+    fn finalize_codex_login_errors_when_login_not_finished() {
+        let app_data = tmp_dir("finalize-missing");
+        assert!(finalize_codex_login(&app_data, "never-started").is_err());
     }
 
     #[test]

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -381,7 +381,7 @@ fn read_env_from_interactive_shell(program: &str, name: &str) -> Option<String> 
     parse_interactive_shell_env_output(&output, START_MARKER, END_MARKER)
 }
 
-fn read_env_from_interactive_shells(name: &str) -> Option<String> {
+pub(crate) fn read_env_from_interactive_shells(name: &str) -> Option<String> {
     let mut programs: Vec<String> = Vec::new();
 
     if let Some(shell) = shell_from_env() {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -73,7 +73,7 @@ export const commands = {
 	clearOpencodeGoKey: () => typedError<null, string>(__TAURI_INVOKE("clear_opencode_go_key")),
 	saveClaudeAccount: (label: string, setupToken: string) => typedError<AccountAdded, string>(__TAURI_INVOKE("save_claude_account", { label, setupToken })),
 	snapshotCursorAccount: (label: string) => typedError<AccountAdded, string>(__TAURI_INVOKE("snapshot_cursor_account", { label })),
-	beginCodexLogin: () => typedError<CodexLoginStarted, string>(__TAURI_INVOKE("begin_codex_login")),
+	beginCodexLogin: (label: string) => typedError<CodexLoginStarted, string>(__TAURI_INVOKE("begin_codex_login", { label })),
 	finishCodexLogin: (stagingId: string) => typedError<AccountAdded, string>(__TAURI_INVOKE("finish_codex_login", { stagingId })),
 	removeAccount: (providerId: string, accountId: string) => typedError<null, string>(__TAURI_INVOKE("remove_account", { providerId, accountId })),
 };

--- a/src/components/add-account-dialog.tsx
+++ b/src/components/add-account-dialog.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect, useState } from "react"
 import { invoke } from "@tauri-apps/api/core"
+import { listen, type UnlistenFn } from "@tauri-apps/api/event"
 import { Button } from "@/components/ui/button"
 import type { AccountAdded, CodexLoginStarted } from "@/bindings"
 
@@ -147,16 +148,22 @@ export function AddClaudeAccountDialog({
   )
 }
 
-/** Add a Codex account via a managed `codex login` into a UsagePal-owned profile. */
+/** Add a Codex account via a managed `codex login` into a UsagePal-owned profile.
+ *
+ * The account is finalized in the backend (it watches the staging dir and emits
+ * `codex:login-complete` once `codex login` writes auth.json), and persisted by
+ * the always-mounted `useAccounts` listener — so the flow completes even though
+ * the tray panel hides the instant the browser takes focus. This dialog only
+ * kicks it off and reflects progress; `onSaved` is intentionally unused here. */
 export function AddCodexAccountDialog({
   onClose,
-  onSaved,
+  onSaved: _onSaved,
 }: {
   onClose: () => void
   onSaved: (providerId: string, account: SavedAccount) => void
 }) {
   const [label, setLabel] = useState("")
-  const [stagingId, setStagingId] = useState<string | null>(null)
+  const [waiting, setWaiting] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -165,8 +172,8 @@ export function AddCodexAccountDialog({
     setBusy(true)
     setError(null)
     try {
-      const started = await invoke<CodexLoginStarted>("begin_codex_login")
-      setStagingId(started.stagingId)
+      await invoke<CodexLoginStarted>("begin_codex_login", { label: label.trim() })
+      setWaiting(true)
     } catch (e) {
       setError(String(e))
     } finally {
@@ -174,35 +181,43 @@ export function AddCodexAccountDialog({
     }
   }
 
-  const handleFinish = async () => {
-    if (busy || !stagingId) return
-    setBusy(true)
-    setError(null)
-    try {
-      const result = await invoke<AccountAdded>("finish_codex_login", { stagingId })
-      onSaved("codex", { accountId: result.accountId, label: label.trim() })
-    } catch (e) {
-      setError(String(e))
-      setBusy(false)
+  // Once a login is in flight, close on success and surface a timeout/error.
+  useEffect(() => {
+    if (!waiting) return
+    let unlistenDone: UnlistenFn | undefined
+    let unlistenFail: UnlistenFn | undefined
+    void listen("codex:login-complete", () => onClose()).then((fn) => {
+      unlistenDone = fn
+    })
+    void listen<{ message: string }>("codex:login-failed", (event) => {
+      setError(event.payload.message)
+      setWaiting(false)
+    }).then((fn) => {
+      unlistenFail = fn
+    })
+    return () => {
+      unlistenDone?.()
+      unlistenFail?.()
     }
-  }
+  }, [waiting, onClose])
 
   return (
     <DialogShell title="Add Codex Account" onClose={onClose}>
       <p className="text-sm text-muted-foreground mb-3">
-        Sign in with Codex — a browser window opens. Finish there, then confirm below.
+        {waiting
+          ? "A browser window opened — finish signing in there. UsagePal adds the account automatically, so you can leave this open."
+          : "Sign in with Codex — a browser window opens. UsagePal adds the account once you finish, no need to come back and confirm."}
       </p>
-      <LabelInput value={label} onChange={setLabel} disabled={busy} />
+      <LabelInput value={label} onChange={setLabel} disabled={busy || waiting} />
+      {waiting && !error && (
+        <p className="text-xs text-muted-foreground mt-2">Waiting for the Codex sign-in to finish…</p>
+      )}
       {error && <p className="text-xs text-destructive mt-2">{error}</p>}
       <div className="flex items-center justify-end gap-2 mt-4">
         <Button variant="ghost" size="sm" disabled={busy} onClick={onClose}>
-          Cancel
+          {waiting ? "Close" : "Cancel"}
         </Button>
-        {stagingId ? (
-          <Button variant="default" size="sm" disabled={busy} onClick={() => void handleFinish()}>
-            I&apos;ve finished signing in
-          </Button>
-        ) : (
+        {!waiting && (
           <Button variant="default" size="sm" disabled={busy} onClick={() => void handleBegin()}>
             Sign in with Codex
           </Button>

--- a/src/components/app/app-content.test.tsx
+++ b/src/components/app/app-content.test.tsx
@@ -52,6 +52,7 @@ import { useAppUiStore } from "@/stores/app-ui-store"
 function createProps(): AppContentProps {
   return {
     displayPlugins: [],
+    groupedPlugins: [],
     settingsPlugins: [],
     selectedPlugin: {
       meta: {

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -4,6 +4,7 @@ import { ProviderDetailPage } from "@/pages/provider-detail"
 import { SettingsPage } from "@/pages/settings"
 import { SharePage } from "@/pages/share"
 import type { DisplayPluginState } from "@/hooks/app/use-app-plugin-views"
+import type { GroupedProviderView } from "@/hooks/app/group-provider-views"
 import type { SettingsPluginState } from "@/hooks/app/use-settings-plugin-list"
 import type { TraySettingsPreview } from "@/hooks/app/use-tray-icon"
 import { useAppPreferencesStore } from "@/stores/app-preferences-store"
@@ -22,6 +23,7 @@ import type {
 
 type AppContentDerivedProps = {
   displayPlugins: DisplayPluginState[]
+  groupedPlugins: GroupedProviderView[]
   settingsPlugins: SettingsPluginState[]
   selectedPlugin: DisplayPluginState | null
 }
@@ -52,6 +54,7 @@ export type AppContentProps = AppContentDerivedProps & AppContentActionProps
 
 export function AppContent({
   displayPlugins,
+  groupedPlugins,
   settingsPlugins,
   selectedPlugin,
   onRetryPlugin,
@@ -118,6 +121,7 @@ export function AppContent({
     return (
       <OverviewPage
         plugins={displayPlugins}
+        groupedPlugins={groupedPlugins}
         onRetryPlugin={onRetryPlugin}
         displayMode={displayMode}
         resetTimerDisplayMode={resetTimerDisplayMode}
@@ -176,9 +180,14 @@ export function AppContent({
     ? () => onRetryPlugin(selectedPlugin.meta.id)
     : /* v8 ignore next */ undefined
 
+  const selectedGroup = selectedPlugin
+    ? groupedPlugins.find((group) => group.meta.id === selectedPlugin.meta.id)
+    : undefined
+
   return (
     <ProviderDetailPage
       plugin={selectedPlugin}
+      accounts={selectedGroup?.accounts}
       onRetry={handleRetry}
       displayMode={displayMode}
       resetTimerDisplayMode={resetTimerDisplayMode}

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -32,6 +32,7 @@ export type AppContentActionProps = {
   onRetryPlugin: (id: string) => void
   onReorder: (orderedIds: string[]) => void
   onToggle: (id: string) => void
+  onSelectAccount: (providerId: string, accountId: string) => void
   onAutoUpdateIntervalChange: (value: AutoUpdateIntervalMinutes) => void
   onThemeModeChange: (mode: ThemeMode) => void
   onDisplayModeChange: (mode: DisplayMode) => void
@@ -60,6 +61,7 @@ export function AppContent({
   onRetryPlugin,
   onReorder,
   onToggle,
+  onSelectAccount,
   onAutoUpdateIntervalChange,
   onThemeModeChange,
   onDisplayModeChange,
@@ -123,6 +125,7 @@ export function AppContent({
         plugins={displayPlugins}
         groupedPlugins={groupedPlugins}
         onRetryPlugin={onRetryPlugin}
+        onSelectAccount={onSelectAccount}
         displayMode={displayMode}
         resetTimerDisplayMode={resetTimerDisplayMode}
         timeFormatMode={timeFormatMode}
@@ -188,6 +191,8 @@ export function AppContent({
     <ProviderDetailPage
       plugin={selectedPlugin}
       accounts={selectedGroup?.accounts}
+      activeIndex={selectedGroup?.activeIndex ?? 0}
+      onSelectAccount={onSelectAccount}
       onRetry={handleRetry}
       displayMode={displayMode}
       resetTimerDisplayMode={resetTimerDisplayMode}

--- a/src/components/app/app-shell.tsx
+++ b/src/components/app/app-shell.tsx
@@ -3,6 +3,7 @@ import { AppContent, type AppContentActionProps } from "@/components/app/app-con
 import { PanelFooter } from "@/components/panel-footer"
 import { SideNav, type NavPlugin, type PluginContextAction } from "@/components/side-nav"
 import type { DisplayPluginState } from "@/hooks/app/use-app-plugin-views"
+import type { GroupedProviderView } from "@/hooks/app/group-provider-views"
 import type { SettingsPluginState } from "@/hooks/app/use-settings-plugin-list"
 import { useAppVersion } from "@/hooks/app/use-app-version"
 import { usePanel } from "@/hooks/app/use-panel"
@@ -15,6 +16,7 @@ type AppShellProps = {
   onRefreshAll: () => void
   navPlugins: NavPlugin[]
   displayPlugins: DisplayPluginState[]
+  groupedPlugins: GroupedProviderView[]
   settingsPlugins: SettingsPluginState[]
   autoUpdateNextAt: number | null
   betaUpdatesEnabled: boolean
@@ -30,6 +32,7 @@ export function AppShell({
   onRefreshAll,
   navPlugins,
   displayPlugins,
+  groupedPlugins,
   settingsPlugins,
   autoUpdateNextAt,
   betaUpdatesEnabled,
@@ -95,6 +98,7 @@ export function AppShell({
               <AppContent
                 {...appContentProps}
                 displayPlugins={displayPlugins}
+                groupedPlugins={groupedPlugins}
                 settingsPlugins={settingsPlugins}
                 selectedPlugin={selectedPlugin}
               />

--- a/src/components/app/main-app.tsx
+++ b/src/components/app/main-app.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react"
 import { useShallow } from "zustand/react/shallow"
 import { AppShell } from "@/components/app/app-shell"
+import { useAccounts } from "@/hooks/app/use-accounts"
 import { useAppPluginViews } from "@/hooks/app/use-app-plugin-views"
 import { useProbe } from "@/hooks/app/use-probe"
 import { usePaceNotifications } from "@/hooks/app/use-pace-notifications"
@@ -235,12 +236,15 @@ export function MainApp() {
     pluginsMeta,
   })
 
+  const { accountsByProvider } = useAccounts()
+
   const { displayPlugins, navPlugins, selectedPlugin } = useAppPluginViews({
     activeView,
     setActiveView,
     pluginSettings,
     pluginsMeta,
     pluginStates,
+    accountsByProvider,
   })
 
   const pluginSettingsRef = useRef(pluginSettings)

--- a/src/components/app/main-app.tsx
+++ b/src/components/app/main-app.tsx
@@ -238,7 +238,7 @@ export function MainApp() {
 
   const { accountsByProvider } = useAccounts()
 
-  const { displayPlugins, navPlugins, selectedPlugin } = useAppPluginViews({
+  const { displayPlugins, groupedPlugins, navPlugins, selectedPlugin } = useAppPluginViews({
     activeView,
     setActiveView,
     pluginSettings,
@@ -301,6 +301,7 @@ export function MainApp() {
       onRefreshAll={handleRefreshAll}
       navPlugins={navPlugins}
       displayPlugins={displayPlugins}
+      groupedPlugins={groupedPlugins}
       settingsPlugins={settingsPlugins}
       autoUpdateNextAt={autoUpdateNextAt}
       betaUpdatesEnabled={betaUpdatesEnabled}

--- a/src/components/app/main-app.tsx
+++ b/src/components/app/main-app.tsx
@@ -125,6 +125,8 @@ export function MainApp() {
     void hydrateShareSettings()
   }, [hydrateShareSettings])
 
+  const { accountsByProvider } = useAccounts()
+
   const { scheduleTrayIconUpdate, traySettingsPreview } = useTrayIcon({
     pluginsMeta,
     pluginSettings,
@@ -135,6 +137,7 @@ export function MainApp() {
     multiTrayProviderCount,
     multiTrayDisplayMode,
     activeView,
+    accountsByProvider,
   })
 
   useEffect(() => {
@@ -235,8 +238,6 @@ export function MainApp() {
     pluginSettings,
     pluginsMeta,
   })
-
-  const { accountsByProvider } = useAccounts()
 
   const { displayPlugins, groupedPlugins, navPlugins, selectedPlugin } = useAppPluginViews({
     activeView,

--- a/src/components/app/main-app.tsx
+++ b/src/components/app/main-app.tsx
@@ -125,7 +125,7 @@ export function MainApp() {
     void hydrateShareSettings()
   }, [hydrateShareSettings])
 
-  const { accountsByProvider } = useAccounts()
+  const { accountsByProvider, selectedByProvider, selectAccount } = useAccounts()
 
   const { scheduleTrayIconUpdate, traySettingsPreview } = useTrayIcon({
     pluginsMeta,
@@ -138,6 +138,7 @@ export function MainApp() {
     multiTrayDisplayMode,
     activeView,
     accountsByProvider,
+    selectedByProvider,
   })
 
   useEffect(() => {
@@ -246,6 +247,7 @@ export function MainApp() {
     pluginsMeta,
     pluginStates,
     accountsByProvider,
+    selectedByProvider,
   })
 
   const pluginSettingsRef = useRef(pluginSettings)
@@ -315,6 +317,7 @@ export function MainApp() {
         onRetryPlugin: handleRetryPlugin,
         onReorder: handleReorder,
         onToggle: handleToggle,
+        onSelectAccount: selectAccount,
         onAutoUpdateIntervalChange: handleAutoUpdateIntervalChange,
         onBetaUpdatesEnabledChange: handleBetaUpdatesEnabledChange,
         onThemeModeChange: handleThemeModeChange,

--- a/src/components/provider-card-swipe.test.ts
+++ b/src/components/provider-card-swipe.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { resolveSwipeTarget } from "@/components/provider-card-swipe"
+
+describe("resolveSwipeTarget", () => {
+  const T = 40
+  it("swiping left past threshold goes to next account", () => {
+    expect(resolveSwipeTarget(-50, T, 0, 3)).toBe(1)
+  })
+  it("swiping right past threshold goes to previous account", () => {
+    expect(resolveSwipeTarget(50, T, 1, 3)).toBe(0)
+  })
+  it("below threshold stays put", () => {
+    expect(resolveSwipeTarget(-20, T, 1, 3)).toBe(1)
+  })
+  it("cannot page past the last account", () => {
+    expect(resolveSwipeTarget(-100, T, 2, 3)).toBe(2)
+  })
+  it("cannot page before the first account", () => {
+    expect(resolveSwipeTarget(100, T, 0, 3)).toBe(0)
+  })
+  it("single account never moves", () => {
+    expect(resolveSwipeTarget(-999, T, 0, 1)).toBe(0)
+  })
+})

--- a/src/components/provider-card-swipe.ts
+++ b/src/components/provider-card-swipe.ts
@@ -1,0 +1,43 @@
+import { useRef } from "react"
+import type { PointerEvent as ReactPointerEvent } from "react"
+
+/** Given a horizontal drag delta (px; negative = leftward), decide the new
+ * account index. Swipe left → next, right → previous, clamped to [0, count-1].
+ * Deltas under `threshold` (or count ≤ 1) keep the current index. */
+export function resolveSwipeTarget(
+  deltaX: number,
+  threshold: number,
+  index: number,
+  count: number
+): number {
+  if (count <= 1) return index
+  if (deltaX <= -threshold && index < count - 1) return index + 1
+  if (deltaX >= threshold && index > 0) return index - 1
+  return index
+}
+
+export function useHorizontalSwipe({
+  index,
+  count,
+  onChange,
+  threshold = 40,
+}: {
+  index: number
+  count: number
+  onChange: (next: number) => void
+  threshold?: number
+}) {
+  const startX = useRef<number | null>(null)
+
+  const onPointerDown = (e: ReactPointerEvent) => {
+    startX.current = e.clientX
+  }
+  const finish = (e: ReactPointerEvent) => {
+    if (startX.current == null) return
+    const delta = e.clientX - startX.current
+    startX.current = null
+    const next = resolveSwipeTarget(delta, threshold, index, count)
+    if (next !== index) onChange(next)
+  }
+  return { onPointerDown, onPointerUp: finish, onPointerCancel: finish }
+}

--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { openUrl } from "@tauri-apps/plugin-opener"
 import { ProviderCard } from "@/components/provider-card"
+import type { AccountSnapshot } from "@/hooks/app/group-provider-views"
 import { groupLinesByType } from "@/lib/group-lines-by-type"
 import { formatResetTooltipText } from "@/lib/reset-tooltip"
 import { REFRESH_COOLDOWN_MS } from "@/lib/settings"
@@ -1385,5 +1386,85 @@ describe("groupLinesByType", () => {
     expect(groups[1].lines).toHaveLength(2)
     expect(groups[2].kind).toBe("other")
     expect(groups[2].lines).toHaveLength(1)
+  })
+})
+
+describe("ProviderCard multi-account", () => {
+  function accountSnap(label: string, plan: string): AccountSnapshot {
+    return {
+      accountId: label.toLowerCase(),
+      label,
+      data: {
+        providerId: "claude",
+        accountId: label.toLowerCase(),
+        displayName: "Claude",
+        plan,
+        lines: [],
+        iconUrl: "",
+      },
+      loading: false,
+      error: null,
+      lastManualRefreshAt: null,
+      lastUpdatedAt: 1,
+    }
+  }
+
+  it("renders a dot per account and the active account's label + plan", () => {
+    render(
+      <ProviderCard
+        name="Claude"
+        displayMode="used"
+        asCard
+        accounts={[accountSnap("Work", "Max"), accountSnap("Home", "Pro")]}
+      />
+    )
+    expect(screen.getAllByRole("tab")).toHaveLength(2)
+    expect(screen.getByText(/Work/)).toBeInTheDocument()
+    expect(screen.getByText("Max")).toBeInTheDocument()
+  })
+
+  it("clicking a dot switches the visible account", async () => {
+    render(
+      <ProviderCard
+        name="Claude"
+        displayMode="used"
+        asCard
+        accounts={[accountSnap("Work", "Max"), accountSnap("Home", "Pro")]}
+      />
+    )
+    await userEvent.click(screen.getAllByRole("tab")[1])
+    expect(screen.getByText(/Home/)).toBeInTheDocument()
+    expect(screen.getByText("Pro")).toBeInTheDocument()
+  })
+
+  it("single account renders no dots and no label separator", () => {
+    render(
+      <ProviderCard
+        name="Codex"
+        displayMode="used"
+        asCard
+        accounts={[
+          {
+            accountId: null,
+            label: null,
+            data: {
+              providerId: "codex",
+              accountId: null,
+              displayName: "Codex",
+              plan: "Plus",
+              lines: [],
+              iconUrl: "",
+            },
+            loading: false,
+            error: null,
+            lastManualRefreshAt: null,
+            lastUpdatedAt: 1,
+          },
+        ]}
+      />
+    )
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument()
+    expect(screen.queryByText(/·/)).not.toBeInTheDocument()
+    expect(screen.getByText("Plus")).toBeInTheDocument()
   })
 })

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo } from "react"
+import { Fragment, useMemo, useState } from "react"
 import { ArrowSquareOut, ArrowsClockwise, Fire, Hourglass, WarningCircle } from "@phosphor-icons/react"
 import { openUrl } from "@tauri-apps/plugin-opener"
 import { Badge } from "@/components/ui/badge"
@@ -10,6 +10,8 @@ import { SkeletonLines } from "@/components/skeleton-lines"
 import { UsageSparkline } from "@/components/usage-sparkline"
 import { PluginError } from "@/components/plugin-error"
 import { ProviderIconMask } from "@/components/provider-icon-mask"
+import { useHorizontalSwipe } from "@/components/provider-card-swipe"
+import type { AccountSnapshot } from "@/hooks/app/group-provider-views"
 import { useNowTicker } from "@/hooks/use-now-ticker"
 import { useDarkMode } from "@/hooks/use-dark-mode"
 import { getAdaptiveBarColor } from "@/lib/color"
@@ -58,6 +60,13 @@ interface ProviderCardProps {
   timeFormatMode?: TimeFormatMode
   onResetTimerDisplayModeToggle?: () => void
   onUsageValueToggle?: () => void
+  /** When provided, the card pages across these per-account snapshots: a dot per
+   * account, plus a "· label" suffix on the header. The active account's
+   * plan/lines/loading/error drive the body. >1 entry shows dots + swipe;
+   * 0 or 1 entry renders exactly as a single-account card. */
+  accounts?: AccountSnapshot[]
+  activeIndex?: number
+  onActiveIndexChange?: (index: number) => void
 }
 
 // "behind" (run out soon) renders a flame instead of a dot — see PaceIndicator.
@@ -123,18 +132,18 @@ function formatRelativeTime(diffMs: number): string {
 
 export function ProviderCard({
   name,
-  plan,
+  plan: propPlan,
   links = [],
   showSeparator = true,
   asCard = false,
   iconUrl,
   pluginId,
-  loading = false,
-  error = null,
-  lines = [],
+  loading: propLoading = false,
+  error: propError = null,
+  lines: propLines = [],
   skeletonLines = [],
-  lastManualRefreshAt,
-  lastUpdatedAt,
+  lastManualRefreshAt: propLastManualRefreshAt,
+  lastUpdatedAt: propLastUpdatedAt,
   onRetry,
   scopeFilter = "all",
   displayMode,
@@ -142,7 +151,35 @@ export function ProviderCard({
   timeFormatMode = "auto",
   onResetTimerDisplayModeToggle,
   onUsageValueToggle,
+  accounts,
+  activeIndex: controlledIndex,
+  onActiveIndexChange,
 }: ProviderCardProps) {
+  // Active account is card-local state unless the parent controls it. When
+  // `accounts` is provided, the active account's snapshot overrides the raw
+  // plan/lines/loading/error props so the render body below is unchanged.
+  const [localIndex, setLocalIndex] = useState(0)
+  const accountCount = accounts?.length ?? 0
+  const rawIndex = controlledIndex ?? localIndex
+  const activeIdx = accountCount > 0 ? Math.min(Math.max(rawIndex, 0), accountCount - 1) : 0
+  const activeAccount = accounts && accountCount > 0 ? accounts[activeIdx] : null
+
+  const setActive = (i: number) => {
+    if (onActiveIndexChange) onActiveIndexChange(i)
+    else setLocalIndex(i)
+  }
+
+  // Effective values: active account wins when accounts provided, else raw props.
+  const plan = activeAccount ? (activeAccount.data?.plan ?? undefined) : propPlan
+  const lines = activeAccount ? (activeAccount.data?.lines ?? []) : propLines
+  const loading = activeAccount ? activeAccount.loading : propLoading
+  const error = activeAccount ? activeAccount.error : propError
+  const lastUpdatedAt = activeAccount ? activeAccount.lastUpdatedAt : propLastUpdatedAt
+  const lastManualRefreshAt = activeAccount ? activeAccount.lastManualRefreshAt : propLastManualRefreshAt
+
+  const swipe = useHorizontalSwipe({ index: activeIdx, count: accountCount, onChange: setActive })
+  const showDots = accountCount > 1
+
   const isDark = useDarkMode()
   const cooldownRemainingMs = useMemo(() => {
     if (!lastManualRefreshAt) return 0
@@ -235,10 +272,37 @@ export function ProviderCard({
   }
 
   return (
-    <div>
+    <div
+      onPointerDown={showDots ? swipe.onPointerDown : undefined}
+      onPointerUp={showDots ? swipe.onPointerUp : undefined}
+      onPointerCancel={showDots ? swipe.onPointerCancel : undefined}
+    >
       <div className={asCard ? "pb-1 pt-2" : "py-3"}>
         <div className="flex items-center justify-between mb-2">
           <div className="relative flex items-center">
+            {showDots && (
+              <div
+                className="mr-2 flex items-center gap-1"
+                role="tablist"
+                aria-label={`${name} accounts`}
+              >
+                {accounts!.map((acct, i) => (
+                  <button
+                    key={acct.accountId ?? i}
+                    type="button"
+                    role="tab"
+                    data-account-dot
+                    aria-selected={i === activeIdx}
+                    aria-label={acct.label ?? `Account ${i + 1}`}
+                    onClick={() => setActive(i)}
+                    className={cn(
+                      "h-1.5 w-1.5 rounded-full transition-colors",
+                      i === activeIdx ? "bg-foreground" : "bg-muted-foreground/40"
+                    )}
+                  />
+                ))}
+              </div>
+            )}
             {asCard && iconUrl && (
               <ProviderIconMask
                 iconUrl={iconUrl}
@@ -249,6 +313,14 @@ export function ProviderCard({
               />
             )}
             <h2 className="text-lg font-semibold" style={{ transform: "translateZ(0)" }}>{name}</h2>
+            {showDots && activeAccount?.label && (
+              <span
+                className="ml-1.5 text-sm text-muted-foreground truncate max-w-[40%]"
+                data-account-label
+              >
+                · {activeAccount.label}
+              </span>
+            )}
             {onRetry && (
               loading ? (
                 <Button

--- a/src/hooks/app/group-provider-views.test.ts
+++ b/src/hooks/app/group-provider-views.test.ts
@@ -60,4 +60,37 @@ describe("groupProviderViews", () => {
     expect(views[0].accounts[0].label).toBe("Work")
     expect(views[0].accounts[0].data).toBeNull()
   })
+
+  describe("activeIndex", () => {
+    const accountsByProvider = {
+      claude: [
+        { accountId: "work", label: "Work", order: 0 },
+        { accountId: "home", label: "Home", order: 1 },
+      ],
+    }
+
+    it("defaults to the primary (order-0) account when nothing is selected", () => {
+      const views = groupProviderViews([meta("claude")], {}, accountsByProvider, {})
+      expect(views[0].activeIndex).toBe(0)
+    })
+
+    it("points at the persisted selection", () => {
+      const views = groupProviderViews([meta("claude")], {}, accountsByProvider, {
+        claude: "home",
+      })
+      expect(views[0].activeIndex).toBe(1)
+    })
+
+    it("falls back to primary when the selection no longer exists", () => {
+      const views = groupProviderViews([meta("claude")], {}, accountsByProvider, {
+        claude: "deleted",
+      })
+      expect(views[0].activeIndex).toBe(0)
+    })
+
+    it("is 0 for a single-account (unregistered) provider", () => {
+      const views = groupProviderViews([meta("codex")], { codex: state("Plus") }, {}, {})
+      expect(views[0].activeIndex).toBe(0)
+    })
+  })
 })

--- a/src/hooks/app/group-provider-views.test.ts
+++ b/src/hooks/app/group-provider-views.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+import { groupProviderViews } from "@/hooks/app/group-provider-views"
+import type { PluginMeta } from "@/lib/plugin-types"
+import type { PluginState } from "@/hooks/app/types"
+
+function meta(id: string): PluginMeta {
+  return {
+    id,
+    name: id[0].toUpperCase() + id.slice(1),
+    iconUrl: "",
+    brandColor: null,
+    lines: [],
+    links: [],
+    primaryCandidates: [],
+    weeklyCandidate: null,
+    multiTrayLines: [],
+    trayPrimaryLabel: null,
+    detected: true,
+  }
+}
+function state(plan: string): PluginState {
+  return {
+    data: { providerId: "x", accountId: null, displayName: "x", plan, lines: [], iconUrl: "" },
+    loading: false,
+    error: null,
+    lastManualRefreshAt: null,
+    lastUpdatedAt: 1,
+  }
+}
+
+describe("groupProviderViews", () => {
+  it("single-account provider yields one unnamed account", () => {
+    const views = groupProviderViews([meta("codex")], { codex: state("Plus") }, {})
+    expect(views).toHaveLength(1)
+    expect(views[0].accounts).toHaveLength(1)
+    expect(views[0].accounts[0].accountId).toBeNull()
+    expect(views[0].accounts[0].label).toBeNull()
+    expect(views[0].accounts[0].data?.plan).toBe("Plus")
+  })
+
+  it("multi-account provider yields ordered, labeled account snapshots", () => {
+    const pluginStates: Record<string, PluginState> = {
+      "claude::home": state("Pro"),
+      "claude::work": state("Max"),
+    }
+    const accountsByProvider = {
+      claude: [
+        { accountId: "work", label: "Work", order: 0 },
+        { accountId: "home", label: "Home", order: 1 },
+      ],
+    }
+    const views = groupProviderViews([meta("claude")], pluginStates, accountsByProvider)
+    expect(views[0].accounts.map((a) => a.label)).toEqual(["Work", "Home"])
+    expect(views[0].accounts.map((a) => a.data?.plan)).toEqual(["Max", "Pro"])
+  })
+
+  it("account with no probe result yet has null data but keeps its label", () => {
+    const accountsByProvider = { claude: [{ accountId: "work", label: "Work", order: 0 }] }
+    const views = groupProviderViews([meta("claude")], {}, accountsByProvider)
+    expect(views[0].accounts[0].label).toBe("Work")
+    expect(views[0].accounts[0].data).toBeNull()
+  })
+})

--- a/src/hooks/app/group-provider-views.ts
+++ b/src/hooks/app/group-provider-views.ts
@@ -1,0 +1,67 @@
+import type { AccountMeta } from "@/lib/settings"
+import type { PluginState } from "@/hooks/app/types"
+import type { PluginMeta } from "@/lib/plugin-types"
+import { stateKey } from "@/hooks/app/use-probe-state"
+
+export type { AccountMeta }
+
+export type AccountSnapshot = {
+  accountId: string | null
+  label: string | null
+  data: PluginState["data"]
+  loading: boolean
+  error: string | null
+  lastManualRefreshAt: number | null
+  lastUpdatedAt: number | null
+}
+
+export type GroupedProviderView = { meta: PluginMeta; accounts: AccountSnapshot[] }
+
+const EMPTY_STATE: PluginState = {
+  data: null,
+  loading: false,
+  error: null,
+  lastManualRefreshAt: null,
+  lastUpdatedAt: null,
+}
+
+function snapshot(
+  accountId: string | null,
+  label: string | null,
+  state: PluginState
+): AccountSnapshot {
+  return {
+    accountId,
+    label,
+    data: state.data,
+    loading: state.loading,
+    error: state.error,
+    lastManualRefreshAt: state.lastManualRefreshAt,
+    lastUpdatedAt: state.lastUpdatedAt,
+  }
+}
+
+/** Group flat, composite-keyed plugin state into one entry per provider, each
+ * carrying an ordered array of per-account snapshots. Providers with no
+ * registered accounts yield a single unnamed (accountId: null) snapshot so the
+ * single-account path is unchanged. */
+export function groupProviderViews(
+  orderedEnabledMeta: PluginMeta[],
+  pluginStates: Record<string, PluginState>,
+  accountsByProvider: Record<string, AccountMeta[]>
+): GroupedProviderView[] {
+  return orderedEnabledMeta.map((meta) => {
+    const accountsMeta = accountsByProvider[meta.id]
+    if (!accountsMeta || accountsMeta.length === 0) {
+      const state = pluginStates[meta.id] ?? EMPTY_STATE
+      return { meta, accounts: [snapshot(null, null, state)] }
+    }
+    const accounts = [...accountsMeta]
+      .sort((a, b) => a.order - b.order)
+      .map((acct) => {
+        const state = pluginStates[stateKey(meta.id, acct.accountId)] ?? EMPTY_STATE
+        return snapshot(acct.accountId, acct.label, state)
+      })
+    return { meta, accounts }
+  })
+}

--- a/src/hooks/app/group-provider-views.ts
+++ b/src/hooks/app/group-provider-views.ts
@@ -1,4 +1,5 @@
-import type { AccountMeta } from "@/lib/settings"
+import type { AccountMeta, SelectedAccounts } from "@/lib/settings"
+import { resolveSelectedAccountId } from "@/lib/settings"
 import type { PluginState } from "@/hooks/app/types"
 import type { PluginMeta } from "@/lib/plugin-types"
 import { stateKey } from "@/hooks/app/use-probe-state"
@@ -15,7 +16,13 @@ export type AccountSnapshot = {
   lastUpdatedAt: number | null
 }
 
-export type GroupedProviderView = { meta: PluginMeta; accounts: AccountSnapshot[] }
+export type GroupedProviderView = {
+  meta: PluginMeta
+  accounts: AccountSnapshot[]
+  /** Index into `accounts` of the persisted selection (primary as fallback);
+   * `0` for providers with no registered accounts. */
+  activeIndex: number
+}
 
 const EMPTY_STATE: PluginState = {
   data: null,
@@ -48,13 +55,14 @@ function snapshot(
 export function groupProviderViews(
   orderedEnabledMeta: PluginMeta[],
   pluginStates: Record<string, PluginState>,
-  accountsByProvider: Record<string, AccountMeta[]>
+  accountsByProvider: Record<string, AccountMeta[]>,
+  selectedByProvider: SelectedAccounts = {}
 ): GroupedProviderView[] {
   return orderedEnabledMeta.map((meta) => {
     const accountsMeta = accountsByProvider[meta.id]
     if (!accountsMeta || accountsMeta.length === 0) {
       const state = pluginStates[meta.id] ?? EMPTY_STATE
-      return { meta, accounts: [snapshot(null, null, state)] }
+      return { meta, accounts: [snapshot(null, null, state)], activeIndex: 0 }
     }
     const accounts = [...accountsMeta]
       .sort((a, b) => a.order - b.order)
@@ -62,6 +70,11 @@ export function groupProviderViews(
         const state = pluginStates[stateKey(meta.id, acct.accountId)] ?? EMPTY_STATE
         return snapshot(acct.accountId, acct.label, state)
       })
-    return { meta, accounts }
+    const selectedId = resolveSelectedAccountId(meta.id, accountsByProvider, selectedByProvider)
+    const activeIndex = Math.max(
+      0,
+      accounts.findIndex((acct) => acct.accountId === selectedId)
+    )
+    return { meta, accounts, activeIndex }
   })
 }

--- a/src/hooks/app/use-accounts.ts
+++ b/src/hooks/app/use-accounts.ts
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from "react"
+import { listen, type UnlistenFn } from "@tauri-apps/api/event"
 import {
   type AccountsByProvider,
   type SelectedAccounts,
   loadAccounts,
   loadSelectedAccounts,
+  saveAccounts,
   saveSelectedAccounts,
+  upsertAccount,
 } from "@/lib/settings"
+
+type CodexLoginComplete = { accountId: string; label: string }
 
 /**
  * Reactive source of registered account metadata, keyed by provider. Seeded from
@@ -51,6 +56,35 @@ export function useAccounts(): {
 
   useEffect(() => {
     void reload()
+  }, [reload])
+
+  // The Codex login finishes in the backend (it watches the staging dir and
+  // emits this once `codex login` writes auth.json), so completion doesn't
+  // depend on the add-account dialog — the tray panel hides the moment the
+  // browser takes focus. Persist the metadata here, in an always-mounted hook,
+  // then reload. Idempotent (upsert by accountId) if several instances run.
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined
+    void listen<CodexLoginComplete>("codex:login-complete", async (event) => {
+      try {
+        const current = await loadAccounts()
+        await saveAccounts(
+          upsertAccount(current, "codex", {
+            accountId: event.payload.accountId,
+            label: event.payload.label.trim() || "Codex",
+            order: current.codex?.length ?? 0,
+          })
+        )
+      } catch (error) {
+        console.error("Failed to persist Codex account:", error)
+      }
+      await reload()
+    }).then((fn) => {
+      unlisten = fn
+    })
+    return () => {
+      unlisten?.()
+    }
   }, [reload])
 
   return { accountsByProvider, selectedByProvider, selectAccount, reload }

--- a/src/hooks/app/use-accounts.ts
+++ b/src/hooks/app/use-accounts.ts
@@ -1,28 +1,57 @@
-import { useCallback, useEffect, useState } from "react"
-import { type AccountsByProvider, loadAccounts } from "@/lib/settings"
+import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  type AccountsByProvider,
+  type SelectedAccounts,
+  loadAccounts,
+  loadSelectedAccounts,
+  saveSelectedAccounts,
+} from "@/lib/settings"
 
 /**
  * Reactive source of registered account metadata, keyed by provider. Seeded from
  * the settings store on mount; `reload` re-reads after an add/remove mutation so
  * the card UI (Plan 3) and settings surfaces reflect the change immediately.
+ *
+ * Also owns the persisted per-provider selection (which account each provider
+ * shows). `selectAccount` writes it through to the store so the choice survives
+ * restart and the tray — reading the same value — stays in sync with the card.
  */
 export function useAccounts(): {
   accountsByProvider: AccountsByProvider
+  selectedByProvider: SelectedAccounts
+  selectAccount: (providerId: string, accountId: string) => void
   reload: () => Promise<void>
 } {
   const [accountsByProvider, setAccountsByProvider] = useState<AccountsByProvider>({})
+  const [selectedByProvider, setSelectedByProvider] = useState<SelectedAccounts>({})
+  const selectedRef = useRef<SelectedAccounts>(selectedByProvider)
 
   const reload = useCallback(async () => {
     try {
-      setAccountsByProvider(await loadAccounts())
+      const [accounts, selected] = await Promise.all([
+        loadAccounts(),
+        loadSelectedAccounts(),
+      ])
+      setAccountsByProvider(accounts)
+      selectedRef.current = selected
+      setSelectedByProvider(selected)
     } catch (error) {
       console.error("Failed to load accounts:", error)
     }
+  }, [])
+
+  const selectAccount = useCallback((providerId: string, accountId: string) => {
+    const next = { ...selectedRef.current, [providerId]: accountId }
+    selectedRef.current = next
+    setSelectedByProvider(next)
+    void saveSelectedAccounts(next).catch((error) => {
+      console.error("Failed to save selected account:", error)
+    })
   }, [])
 
   useEffect(() => {
     void reload()
   }, [reload])
 
-  return { accountsByProvider, reload }
+  return { accountsByProvider, selectedByProvider, selectAccount, reload }
 }

--- a/src/hooks/app/use-app-plugin-views.test.ts
+++ b/src/hooks/app/use-app-plugin-views.test.ts
@@ -42,6 +42,7 @@ describe("useAppPluginViews", () => {
             lastUpdatedAt: null,
           },
         },
+        accountsByProvider: {},
       })
     )
 
@@ -72,6 +73,7 @@ describe("useAppPluginViews", () => {
         pluginSettings,
         pluginsMeta: [createPluginMeta("codex", "Codex")],
         pluginStates: {},
+        accountsByProvider: {},
       })
     )
 
@@ -91,6 +93,7 @@ describe("useAppPluginViews", () => {
           pluginSettings,
           pluginsMeta,
           pluginStates: {},
+          accountsByProvider: {},
         }),
       { initialProps: { pluginSettings: null } }
     )
@@ -122,6 +125,7 @@ describe("useAppPluginViews", () => {
         pluginSettings,
         pluginsMeta: [createPluginMeta("codex", "Codex")],
         pluginStates: {},
+        accountsByProvider: {},
       })
     )
 

--- a/src/hooks/app/use-app-plugin-views.ts
+++ b/src/hooks/app/use-app-plugin-views.ts
@@ -3,6 +3,11 @@ import type { ActiveView, NavPlugin } from "@/components/side-nav"
 import type { PluginMeta } from "@/lib/plugin-types"
 import type { PluginSettings } from "@/lib/settings"
 import type { PluginState } from "@/hooks/app/types"
+import {
+  type AccountMeta,
+  type GroupedProviderView,
+  groupProviderViews,
+} from "@/hooks/app/group-provider-views"
 
 export type DisplayPluginState = { meta: PluginMeta } & PluginState
 
@@ -12,6 +17,7 @@ type UseAppPluginViewsArgs = {
   pluginSettings: PluginSettings | null
   pluginsMeta: PluginMeta[]
   pluginStates: Record<string, PluginState>
+  accountsByProvider: Record<string, AccountMeta[]>
 }
 
 export function useAppPluginViews({
@@ -20,40 +26,49 @@ export function useAppPluginViews({
   pluginSettings,
   pluginsMeta,
   pluginStates,
+  accountsByProvider,
 }: UseAppPluginViewsArgs) {
-  const displayPlugins = useMemo<DisplayPluginState[]>(() => {
+  const orderedEnabledMeta = useMemo<PluginMeta[]>(() => {
     if (!pluginSettings) return []
     const disabledSet = new Set(pluginSettings.disabled)
     const metaById = new Map(pluginsMeta.map((plugin) => [plugin.id, plugin]))
-
-    return pluginSettings.order
-      .filter((id) => !disabledSet.has(id))
-      .map((id) => {
-        const meta = metaById.get(id)
-        if (!meta) return null
-        const state =
-          pluginStates[id] ?? { data: null, loading: false, error: null, lastManualRefreshAt: null, lastUpdatedAt: null }
-        return { meta, ...state }
-      })
-      .filter((plugin): plugin is DisplayPluginState => Boolean(plugin))
-  }, [pluginSettings, pluginStates, pluginsMeta])
-
-  const navPlugins = useMemo<NavPlugin[]>(() => {
-    if (!pluginSettings) return []
-    const disabledSet = new Set(pluginSettings.disabled)
-    const metaById = new Map(pluginsMeta.map((plugin) => [plugin.id, plugin]))
-
     return pluginSettings.order
       .filter((id) => !disabledSet.has(id))
       .map((id) => metaById.get(id))
       .filter((plugin): plugin is PluginMeta => Boolean(plugin))
-      .map((plugin) => ({
+  }, [pluginSettings, pluginsMeta])
+
+  const groupedPlugins = useMemo<GroupedProviderView[]>(
+    () => groupProviderViews(orderedEnabledMeta, pluginStates, accountsByProvider),
+    [orderedEnabledMeta, pluginStates, accountsByProvider]
+  )
+
+  const displayPlugins = useMemo<DisplayPluginState[]>(
+    () =>
+      groupedPlugins.map(({ meta, accounts }) => {
+        const first = accounts[0]
+        return {
+          meta,
+          data: first.data,
+          loading: first.loading,
+          error: first.error,
+          lastManualRefreshAt: first.lastManualRefreshAt,
+          lastUpdatedAt: first.lastUpdatedAt,
+        }
+      }),
+    [groupedPlugins]
+  )
+
+  const navPlugins = useMemo<NavPlugin[]>(
+    () =>
+      orderedEnabledMeta.map((plugin) => ({
         id: plugin.id,
         name: plugin.name,
         iconUrl: plugin.iconUrl,
         brandColor: plugin.brandColor ?? undefined,
-      }))
-  }, [pluginSettings, pluginsMeta])
+      })),
+    [orderedEnabledMeta]
+  )
 
   useEffect(() => {
     if (activeView === "home" || activeView === "settings") return
@@ -73,6 +88,7 @@ export function useAppPluginViews({
 
   return {
     displayPlugins,
+    groupedPlugins,
     navPlugins,
     selectedPlugin,
   }

--- a/src/hooks/app/use-app-plugin-views.ts
+++ b/src/hooks/app/use-app-plugin-views.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from "react"
 import type { ActiveView, NavPlugin } from "@/components/side-nav"
 import type { PluginMeta } from "@/lib/plugin-types"
-import type { PluginSettings } from "@/lib/settings"
+import type { PluginSettings, SelectedAccounts } from "@/lib/settings"
 import type { PluginState } from "@/hooks/app/types"
 import {
   type AccountMeta,
@@ -18,6 +18,7 @@ type UseAppPluginViewsArgs = {
   pluginsMeta: PluginMeta[]
   pluginStates: Record<string, PluginState>
   accountsByProvider: Record<string, AccountMeta[]>
+  selectedByProvider?: SelectedAccounts
 }
 
 export function useAppPluginViews({
@@ -27,6 +28,7 @@ export function useAppPluginViews({
   pluginsMeta,
   pluginStates,
   accountsByProvider,
+  selectedByProvider = {},
 }: UseAppPluginViewsArgs) {
   const orderedEnabledMeta = useMemo<PluginMeta[]>(() => {
     if (!pluginSettings) return []
@@ -39,8 +41,8 @@ export function useAppPluginViews({
   }, [pluginSettings, pluginsMeta])
 
   const groupedPlugins = useMemo<GroupedProviderView[]>(
-    () => groupProviderViews(orderedEnabledMeta, pluginStates, accountsByProvider),
-    [orderedEnabledMeta, pluginStates, accountsByProvider]
+    () => groupProviderViews(orderedEnabledMeta, pluginStates, accountsByProvider, selectedByProvider),
+    [orderedEnabledMeta, pluginStates, accountsByProvider, selectedByProvider]
   )
 
   const displayPlugins = useMemo<DisplayPluginState[]>(

--- a/src/hooks/app/use-tray-icon.test.ts
+++ b/src/hooks/app/use-tray-icon.test.ts
@@ -4,7 +4,23 @@ import type { PluginSettings } from "@/lib/settings"
 import {
   buildTraySettingsPreview,
   getMultiTrayProviderIds,
+  resolveTrayStateKey,
 } from "@/hooks/app/use-tray-icon"
+
+describe("resolveTrayStateKey", () => {
+  it("returns providerId when the provider has no registered accounts", () => {
+    expect(resolveTrayStateKey("codex", {})).toBe("codex")
+  })
+  it("returns the first (order-0) account's composite key", () => {
+    const accountsByProvider = {
+      claude: [
+        { accountId: "home", label: "Home", order: 1 },
+        { accountId: "work", label: "Work", order: 0 },
+      ],
+    }
+    expect(resolveTrayStateKey("claude", accountsByProvider)).toBe("claude::work")
+  })
+})
 
 const pluginsMeta: PluginMeta[] = [
   {
@@ -146,6 +162,47 @@ describe("buildTraySettingsPreview", () => {
       sessionFraction: 0.42,
       weeklyFraction: 0.18,
     })
+  })
+
+  it("reads the primary account's composite-key state when accounts are registered", () => {
+    const preview = buildTraySettingsPreview({
+      pluginsMeta,
+      pluginSettings: { order: ["claude"], disabled: [] },
+      pluginStates: {
+        // Decoy under the bare providerId — must be ignored once accounts exist.
+        claude: {
+          data: {
+            providerId: "claude",
+            lines: [{ type: "progress", label: "Session", used: 10, limit: 100 }],
+          },
+          loading: false,
+          error: null,
+        },
+        "claude::work": {
+          data: {
+            providerId: "claude",
+            lines: [{ type: "progress", label: "Session", used: 70, limit: 100 }],
+          },
+          loading: false,
+          error: null,
+        },
+      },
+      displayMode: "used",
+      menubarMetric: "default",
+      activeView: "claude",
+      lastTrayProviderId: null,
+      accountsByProvider: {
+        claude: [
+          { accountId: "home", label: "Home", order: 1 },
+          { accountId: "work", label: "Work", order: 0 },
+        ],
+      },
+    })
+
+    expect(preview.providerBars[0]?.fraction).toBe(0.7)
+    expect(preview.providerPercentText).toBe("70%")
+    expect(preview.bars[0]?.fraction).toBe(0.7)
+    expect(preview.multiProviders[0]).toMatchObject({ id: "claude", sessionText: "70%" })
   })
 
   it("uses Total usage for Cursor provider and bars preview", () => {

--- a/src/hooks/app/use-tray-icon.test.ts
+++ b/src/hooks/app/use-tray-icon.test.ts
@@ -11,7 +11,7 @@ describe("resolveTrayStateKey", () => {
   it("returns providerId when the provider has no registered accounts", () => {
     expect(resolveTrayStateKey("codex", {})).toBe("codex")
   })
-  it("returns the first (order-0) account's composite key", () => {
+  it("returns the primary (order-0) account's composite key when nothing is selected", () => {
     const accountsByProvider = {
       claude: [
         { accountId: "home", label: "Home", order: 1 },
@@ -19,6 +19,18 @@ describe("resolveTrayStateKey", () => {
       ],
     }
     expect(resolveTrayStateKey("claude", accountsByProvider)).toBe("claude::work")
+  })
+
+  it("follows the persisted selection when present", () => {
+    const accountsByProvider = {
+      claude: [
+        { accountId: "home", label: "Home", order: 1 },
+        { accountId: "work", label: "Work", order: 0 },
+      ],
+    }
+    expect(resolveTrayStateKey("claude", accountsByProvider, { claude: "home" })).toBe(
+      "claude::home",
+    )
   })
 })
 
@@ -203,6 +215,48 @@ describe("buildTraySettingsPreview", () => {
     expect(preview.providerPercentText).toBe("70%")
     expect(preview.bars[0]?.fraction).toBe(0.7)
     expect(preview.multiProviders[0]).toMatchObject({ id: "claude", sessionText: "70%" })
+  })
+
+  it("follows the persisted selection over the primary account", () => {
+    const preview = buildTraySettingsPreview({
+      pluginsMeta,
+      pluginSettings: { order: ["claude"], disabled: [] },
+      pluginStates: {
+        // order-0 primary — must be ignored once "home" is selected.
+        "claude::work": {
+          data: {
+            providerId: "claude",
+            lines: [{ type: "progress", label: "Session", used: 10, limit: 100 }],
+          },
+          loading: false,
+          error: null,
+        },
+        "claude::home": {
+          data: {
+            providerId: "claude",
+            lines: [{ type: "progress", label: "Session", used: 85, limit: 100 }],
+          },
+          loading: false,
+          error: null,
+        },
+      },
+      displayMode: "used",
+      menubarMetric: "default",
+      activeView: "claude",
+      lastTrayProviderId: null,
+      accountsByProvider: {
+        claude: [
+          { accountId: "work", label: "Work", order: 0 },
+          { accountId: "home", label: "Home", order: 1 },
+        ],
+      },
+      selectedByProvider: { claude: "home" },
+    })
+
+    expect(preview.providerBars[0]?.fraction).toBe(0.85)
+    expect(preview.providerPercentText).toBe("85%")
+    expect(preview.bars[0]?.fraction).toBe(0.85)
+    expect(preview.multiProviders[0]).toMatchObject({ id: "claude", sessionText: "85%" })
   })
 
   it("uses Total usage for Cursor provider and bars preview", () => {

--- a/src/hooks/app/use-tray-icon.ts
+++ b/src/hooks/app/use-tray-icon.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { resolveResource } from "@tauri-apps/api/path"
 import { TrayIcon } from "@tauri-apps/api/tray"
 import type { PluginMeta } from "@/lib/plugin-types"
-import type { DisplayMode, MenubarIconStyle, MenubarMetric, MultiTrayDisplayMode, PluginSettings } from "@/lib/settings"
+import type { AccountsByProvider, DisplayMode, MenubarIconStyle, MenubarMetric, MultiTrayDisplayMode, PluginSettings } from "@/lib/settings"
 import { getEnabledPluginIds } from "@/lib/settings"
 import {
   getTrayIconSizePx,
@@ -10,7 +10,7 @@ import {
   renderMultiTrayIcon,
   renderTrayBarsIcon,
 } from "@/lib/tray-bars-icon"
-import { getTrayPrimaryBars, getTrayMultiProviderMetrics, type TrayPrimaryBar } from "@/lib/tray-primary-progress"
+import { getTrayPrimaryBars, getTrayMultiProviderMetrics, resolveTrayStateKey, type TrayPrimaryBar } from "@/lib/tray-primary-progress"
 import {
   formatTrayPercentIfPresent,
   formatTrayPercentText,
@@ -34,6 +34,7 @@ type UseTrayIconArgs = {
   multiTrayProviderCount: number
   multiTrayDisplayMode: MultiTrayDisplayMode
   activeView: string
+  accountsByProvider: AccountsByProvider
 }
 
 export type TrayMultiProviderPreview = {
@@ -144,6 +145,7 @@ function buildTraySettingsPreview(args: {
   menubarMetric: MenubarMetric
   activeView: string
   lastTrayProviderId: string | null
+  accountsByProvider?: AccountsByProvider
 }): TraySettingsPreview {
   const {
     pluginsMeta,
@@ -153,6 +155,7 @@ function buildTraySettingsPreview(args: {
     menubarMetric,
     activeView,
     lastTrayProviderId,
+    accountsByProvider = {},
   } = args
 
   const enabledPluginIds = getEnabledPluginIds(pluginSettings)
@@ -170,6 +173,7 @@ function buildTraySettingsPreview(args: {
     maxBars: 4,
     displayMode,
     preferWeekly,
+    accountsByProvider,
   })
 
   const providerBars = trayProviderId
@@ -181,6 +185,7 @@ function buildTraySettingsPreview(args: {
         displayMode,
         pluginId: trayProviderId,
         preferWeekly,
+        accountsByProvider,
       })
     : []
 
@@ -199,6 +204,7 @@ function buildTraySettingsPreview(args: {
       pluginSettings,
       pluginStates,
       displayMode,
+      accountsByProvider,
     })
 
     return {
@@ -221,7 +227,7 @@ function buildTraySettingsPreview(args: {
   }
 }
 
-export { buildTraySettingsPreview, getMultiTrayProviderIds }
+export { buildTraySettingsPreview, getMultiTrayProviderIds, resolveTrayStateKey }
 
 export function useTrayIcon({
   pluginsMeta,
@@ -233,6 +239,7 @@ export function useTrayIcon({
   multiTrayProviderCount,
   multiTrayDisplayMode,
   activeView,
+  accountsByProvider,
 }: UseTrayIconArgs) {
   const trayRef = useRef<TrayIcon | null>(null)
   const trayGaugeIconPathRef = useRef<string | null>(null)
@@ -254,6 +261,7 @@ export function useTrayIcon({
   const multiTrayProviderCountRef = useRef(multiTrayProviderCount)
   const multiTrayDisplayModeRef = useRef(multiTrayDisplayMode)
   const activeViewRef = useRef(activeView)
+  const accountsByProviderRef = useRef(accountsByProvider)
   const lastTrayProviderIdRef = useRef<string | null>(null)
 
   // Single sync effect replaces 7 individual useRef+useEffect pairs.
@@ -269,6 +277,7 @@ export function useTrayIcon({
     multiTrayProviderCountRef.current = multiTrayProviderCount
     multiTrayDisplayModeRef.current = multiTrayDisplayMode
     activeViewRef.current = activeView
+    accountsByProviderRef.current = accountsByProvider
   })
 
   const scheduleTrayIconUpdate = useCallback((
@@ -382,6 +391,7 @@ export function useTrayIcon({
         menubarMetric: menubarMetricRef.current,
         activeView: activeViewRef.current,
         lastTrayProviderId: lastTrayProviderIdRef.current,
+        accountsByProvider: accountsByProviderRef.current,
       })
       setTraySettingsPreview((prev) =>
         isSameTraySettingsPreview(prev, nextPreview) ? prev : nextPreview
@@ -405,6 +415,7 @@ export function useTrayIcon({
               pluginSettings: currentSettings,
               pluginStates: pluginStatesRef.current,
               displayMode: displayModeRef.current,
+              accountsByProvider: accountsByProviderRef.current,
             })
 
             return { id: pluginId, sessionFraction, weeklyFraction }

--- a/src/hooks/app/use-tray-icon.ts
+++ b/src/hooks/app/use-tray-icon.ts
@@ -624,6 +624,14 @@ export function useTrayIcon({
     scheduleTrayIconUpdate("settings", 0)
   }, [activeView, scheduleTrayIconUpdate, trayReady])
 
+  // Repaint when the shown account changes (swipe → persisted selection) or an
+  // account is added/removed. Affects every style, including multi, since each
+  // provider's icon reads its selected account's state.
+  useEffect(() => {
+    if (!trayReady) return
+    scheduleTrayIconUpdate("settings", 0)
+  }, [accountsByProvider, selectedByProvider, scheduleTrayIconUpdate, trayReady])
+
   useEffect(() => {
     return () => {
       if (trayUpdateTimerRef.current !== null) {

--- a/src/hooks/app/use-tray-icon.ts
+++ b/src/hooks/app/use-tray-icon.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { resolveResource } from "@tauri-apps/api/path"
 import { TrayIcon } from "@tauri-apps/api/tray"
 import type { PluginMeta } from "@/lib/plugin-types"
-import type { AccountsByProvider, DisplayMode, MenubarIconStyle, MenubarMetric, MultiTrayDisplayMode, PluginSettings } from "@/lib/settings"
+import type { AccountsByProvider, DisplayMode, MenubarIconStyle, MenubarMetric, MultiTrayDisplayMode, PluginSettings, SelectedAccounts } from "@/lib/settings"
 import { getEnabledPluginIds } from "@/lib/settings"
 import {
   getTrayIconSizePx,
@@ -35,6 +35,7 @@ type UseTrayIconArgs = {
   multiTrayDisplayMode: MultiTrayDisplayMode
   activeView: string
   accountsByProvider: AccountsByProvider
+  selectedByProvider: SelectedAccounts
 }
 
 export type TrayMultiProviderPreview = {
@@ -146,6 +147,7 @@ function buildTraySettingsPreview(args: {
   activeView: string
   lastTrayProviderId: string | null
   accountsByProvider?: AccountsByProvider
+  selectedByProvider?: SelectedAccounts
 }): TraySettingsPreview {
   const {
     pluginsMeta,
@@ -156,6 +158,7 @@ function buildTraySettingsPreview(args: {
     activeView,
     lastTrayProviderId,
     accountsByProvider = {},
+    selectedByProvider = {},
   } = args
 
   const enabledPluginIds = getEnabledPluginIds(pluginSettings)
@@ -174,6 +177,7 @@ function buildTraySettingsPreview(args: {
     displayMode,
     preferWeekly,
     accountsByProvider,
+    selectedByProvider,
   })
 
   const providerBars = trayProviderId
@@ -186,6 +190,7 @@ function buildTraySettingsPreview(args: {
         pluginId: trayProviderId,
         preferWeekly,
         accountsByProvider,
+        selectedByProvider,
       })
     : []
 
@@ -205,6 +210,7 @@ function buildTraySettingsPreview(args: {
       pluginStates,
       displayMode,
       accountsByProvider,
+      selectedByProvider,
     })
 
     return {
@@ -240,6 +246,7 @@ export function useTrayIcon({
   multiTrayDisplayMode,
   activeView,
   accountsByProvider,
+  selectedByProvider,
 }: UseTrayIconArgs) {
   const trayRef = useRef<TrayIcon | null>(null)
   const trayGaugeIconPathRef = useRef<string | null>(null)
@@ -262,6 +269,7 @@ export function useTrayIcon({
   const multiTrayDisplayModeRef = useRef(multiTrayDisplayMode)
   const activeViewRef = useRef(activeView)
   const accountsByProviderRef = useRef(accountsByProvider)
+  const selectedByProviderRef = useRef(selectedByProvider)
   const lastTrayProviderIdRef = useRef<string | null>(null)
 
   // Single sync effect replaces 7 individual useRef+useEffect pairs.
@@ -278,6 +286,7 @@ export function useTrayIcon({
     multiTrayDisplayModeRef.current = multiTrayDisplayMode
     activeViewRef.current = activeView
     accountsByProviderRef.current = accountsByProvider
+    selectedByProviderRef.current = selectedByProvider
   })
 
   const scheduleTrayIconUpdate = useCallback((
@@ -392,6 +401,7 @@ export function useTrayIcon({
         activeView: activeViewRef.current,
         lastTrayProviderId: lastTrayProviderIdRef.current,
         accountsByProvider: accountsByProviderRef.current,
+        selectedByProvider: selectedByProviderRef.current,
       })
       setTraySettingsPreview((prev) =>
         isSameTraySettingsPreview(prev, nextPreview) ? prev : nextPreview
@@ -416,6 +426,7 @@ export function useTrayIcon({
               pluginStates: pluginStatesRef.current,
               displayMode: displayModeRef.current,
               accountsByProvider: accountsByProviderRef.current,
+              selectedByProvider: selectedByProviderRef.current,
             })
 
             return { id: pluginId, sessionFraction, weeklyFraction }

--- a/src/lib/settings.accounts.test.ts
+++ b/src/lib/settings.accounts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { removeAccountMeta, upsertAccount } from "@/lib/settings"
+import { removeAccountMeta, resolveSelectedAccountId, upsertAccount } from "@/lib/settings"
 
 describe("account metadata helpers", () => {
   it("appends a new account with the next order", () => {
@@ -16,5 +16,30 @@ describe("account metadata helpers", () => {
   it("removes an account by id and drops empty providers", () => {
     const base = { claude: [{ accountId: "a1", label: "Work", order: 0 }] }
     expect(removeAccountMeta(base, "claude", "a1")).toEqual({})
+  })
+})
+
+describe("resolveSelectedAccountId", () => {
+  const accounts = {
+    claude: [
+      { accountId: "work", label: "Work", order: 0 },
+      { accountId: "home", label: "Home", order: 1 },
+    ],
+  }
+
+  it("returns null for a provider with no registered accounts", () => {
+    expect(resolveSelectedAccountId("codex", {}, {})).toBeNull()
+  })
+
+  it("returns the primary (lowest-order) account when nothing is selected", () => {
+    expect(resolveSelectedAccountId("claude", accounts, {})).toBe("work")
+  })
+
+  it("returns the persisted selection when it still names a registered account", () => {
+    expect(resolveSelectedAccountId("claude", accounts, { claude: "home" })).toBe("home")
+  })
+
+  it("falls back to the primary when the selection no longer exists", () => {
+    expect(resolveSelectedAccountId("claude", accounts, { claude: "deleted" })).toBe("work")
   })
 })

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -285,6 +285,42 @@ export function removeAccountMeta(
   return copy;
 }
 
+// The account shown for a provider across the card UI and the menubar tray:
+// providerId -> accountId. Persisted so the choice survives restart and stays
+// consistent between surfaces (the card opens to it, the tray follows it).
+export type SelectedAccounts = Record<string, string>;
+
+const SELECTED_ACCOUNTS_KEY = "selectedAccounts";
+
+export async function loadSelectedAccounts(): Promise<SelectedAccounts> {
+  const stored = await store.get<SelectedAccounts>(SELECTED_ACCOUNTS_KEY);
+  return stored && typeof stored === "object" ? stored : {};
+}
+
+export async function saveSelectedAccounts(selected: SelectedAccounts): Promise<void> {
+  await store.set(SELECTED_ACCOUNTS_KEY, selected);
+  await store.save();
+}
+
+/**
+ * The accountId a provider should display: the persisted selection when it
+ * still names a registered account, otherwise the primary (lowest-`order`)
+ * account, and `null` when the provider has no registered accounts (the
+ * implicit single-account path). Shared by the card UI and the tray so both
+ * surfaces resolve to the same account.
+ */
+export function resolveSelectedAccountId(
+  providerId: string,
+  accountsByProvider: AccountsByProvider,
+  selectedByProvider: SelectedAccounts
+): string | null {
+  const accounts = accountsByProvider[providerId];
+  if (!accounts || accounts.length === 0) return null;
+  const selected = selectedByProvider[providerId];
+  if (selected && accounts.some((a) => a.accountId === selected)) return selected;
+  return accounts.reduce((best, a) => (a.order < best.order ? a : best)).accountId;
+}
+
 /** Apply an onboarding provider selection: `keep` ids leave the disabled list,
  * `drop` ids join it. Pure — callers persist via savePluginSettings. */
 export function mergeProviderSelection(

--- a/src/lib/tray-primary-progress.ts
+++ b/src/lib/tray-primary-progress.ts
@@ -1,5 +1,5 @@
 import type { PluginMeta, PluginOutput } from "@/lib/plugin-types"
-import type { PluginSettings } from "@/lib/settings"
+import type { AccountsByProvider, PluginSettings } from "@/lib/settings"
 import { DEFAULT_DISPLAY_MODE, type DisplayMode } from "@/lib/settings"
 import { clamp01 } from "@/lib/utils"
 import { selectEscalatedLine } from "@/lib/metric-escalation"
@@ -26,6 +26,24 @@ function isUsableProgressLine(line: PluginOutput["lines"][number]): line is Usab
   return line.type === "progress" && line.used != null && line.limit != null
 }
 
+/**
+ * The `pluginStates` key the tray should read for a provider. Probe/cache state
+ * is keyed `providerId::accountId` (see `stateKey` in use-probe-state) once a
+ * provider has registered accounts, so the bare `providerId` key is empty for
+ * those providers. The tray follows the primary (lowest-`order`) account; with
+ * no registered accounts it falls back to the bare `providerId` — keeping the
+ * single-account path byte-for-byte unchanged.
+ */
+export function resolveTrayStateKey(
+  providerId: string,
+  accountsByProvider: AccountsByProvider,
+): string {
+  const accounts = accountsByProvider[providerId]
+  if (!accounts || accounts.length === 0) return providerId
+  const primary = accounts.reduce((best, acct) => (acct.order < best.order ? acct : best))
+  return `${providerId}::${primary.accountId}`
+}
+
 export function getTrayPrimaryBars(args: {
   pluginsMeta: PluginMeta[]
   pluginSettings: PluginSettings | null
@@ -34,6 +52,7 @@ export function getTrayPrimaryBars(args: {
   displayMode?: DisplayMode
   pluginId?: string
   preferWeekly?: boolean
+  accountsByProvider?: AccountsByProvider
 }): TrayPrimaryBar[] {
   const {
     pluginsMeta,
@@ -43,6 +62,7 @@ export function getTrayPrimaryBars(args: {
     displayMode = DEFAULT_DISPLAY_MODE,
     pluginId,
     preferWeekly = false,
+    accountsByProvider = {},
   } = args
   if (!pluginSettings) return []
 
@@ -64,7 +84,7 @@ export function getTrayPrimaryBars(args: {
     // provider is intentionally skipped.
     if (!meta.primaryCandidates || meta.primaryCandidates.length === 0) continue
 
-    const state = pluginStates[id]
+    const state = pluginStates[resolveTrayStateKey(id, accountsByProvider)]
     const data = state?.data ?? null
 
     let fraction: number | undefined
@@ -135,6 +155,7 @@ export function getTrayWeeklyFraction(args: {
   pluginSettings: PluginSettings | null
   pluginStates: Record<string, PluginState | undefined>
   displayMode?: DisplayMode
+  accountsByProvider?: AccountsByProvider
 }): number | undefined {
   const {
     pluginId,
@@ -142,6 +163,7 @@ export function getTrayWeeklyFraction(args: {
     pluginSettings,
     pluginStates,
     displayMode = DEFAULT_DISPLAY_MODE,
+    accountsByProvider = {},
   } = args
   if (!pluginSettings) return undefined
   if (pluginSettings.disabled.includes(pluginId)) return undefined
@@ -150,7 +172,7 @@ export function getTrayWeeklyFraction(args: {
   const weeklyLabel = meta?.weeklyCandidate
   if (!weeklyLabel) return undefined
 
-  const data = pluginStates[pluginId]?.data ?? null
+  const data = pluginStates[resolveTrayStateKey(pluginId, accountsByProvider)]?.data ?? null
   if (!data) return undefined
 
   const metricLine = data.lines.find(
@@ -197,6 +219,7 @@ export function getTrayMultiProviderMetrics(args: {
   pluginSettings: PluginSettings | null
   pluginStates: Record<string, PluginState | undefined>
   displayMode?: DisplayMode
+  accountsByProvider?: AccountsByProvider
 }): TrayMultiProviderMetrics {
   const {
     pluginId,
@@ -204,6 +227,7 @@ export function getTrayMultiProviderMetrics(args: {
     pluginSettings,
     pluginStates,
     displayMode = DEFAULT_DISPLAY_MODE,
+    accountsByProvider = {},
   } = args
   if (!pluginSettings) return {}
   if (pluginSettings.disabled.includes(pluginId)) return {}
@@ -211,7 +235,7 @@ export function getTrayMultiProviderMetrics(args: {
   const meta = pluginsMeta.find((p) => p.id === pluginId)
   const multiTrayLines = meta?.multiTrayLines ?? []
   if (multiTrayLines.length > 0) {
-    const data = pluginStates[pluginId]?.data ?? null
+    const data = pluginStates[resolveTrayStateKey(pluginId, accountsByProvider)]?.data ?? null
     return {
       sessionFraction: multiTrayLines[0]
         ? getProgressLineFraction(data, multiTrayLines[0], displayMode)
@@ -230,6 +254,7 @@ export function getTrayMultiProviderMetrics(args: {
     displayMode,
     pluginId,
     preferWeekly: false,
+    accountsByProvider,
   })[0]?.fraction
 
   const weeklyFraction = getTrayWeeklyFraction({
@@ -238,6 +263,7 @@ export function getTrayMultiProviderMetrics(args: {
     pluginSettings,
     pluginStates,
     displayMode,
+    accountsByProvider,
   })
 
   return { sessionFraction, weeklyFraction }

--- a/src/lib/tray-primary-progress.ts
+++ b/src/lib/tray-primary-progress.ts
@@ -1,6 +1,6 @@
 import type { PluginMeta, PluginOutput } from "@/lib/plugin-types"
-import type { AccountsByProvider, PluginSettings } from "@/lib/settings"
-import { DEFAULT_DISPLAY_MODE, type DisplayMode } from "@/lib/settings"
+import type { AccountsByProvider, PluginSettings, SelectedAccounts } from "@/lib/settings"
+import { DEFAULT_DISPLAY_MODE, type DisplayMode, resolveSelectedAccountId } from "@/lib/settings"
 import { clamp01 } from "@/lib/utils"
 import { selectEscalatedLine } from "@/lib/metric-escalation"
 
@@ -30,18 +30,18 @@ function isUsableProgressLine(line: PluginOutput["lines"][number]): line is Usab
  * The `pluginStates` key the tray should read for a provider. Probe/cache state
  * is keyed `providerId::accountId` (see `stateKey` in use-probe-state) once a
  * provider has registered accounts, so the bare `providerId` key is empty for
- * those providers. The tray follows the primary (lowest-`order`) account; with
- * no registered accounts it falls back to the bare `providerId` — keeping the
- * single-account path byte-for-byte unchanged.
+ * those providers. The tray follows the same persisted selection the card UI
+ * shows (`resolveSelectedAccountId`: the chosen account, else the primary
+ * lowest-`order` one); with no registered accounts it falls back to the bare
+ * `providerId` — keeping the single-account path byte-for-byte unchanged.
  */
 export function resolveTrayStateKey(
   providerId: string,
   accountsByProvider: AccountsByProvider,
+  selectedByProvider: SelectedAccounts = {},
 ): string {
-  const accounts = accountsByProvider[providerId]
-  if (!accounts || accounts.length === 0) return providerId
-  const primary = accounts.reduce((best, acct) => (acct.order < best.order ? acct : best))
-  return `${providerId}::${primary.accountId}`
+  const accountId = resolveSelectedAccountId(providerId, accountsByProvider, selectedByProvider)
+  return accountId ? `${providerId}::${accountId}` : providerId
 }
 
 export function getTrayPrimaryBars(args: {
@@ -53,6 +53,7 @@ export function getTrayPrimaryBars(args: {
   pluginId?: string
   preferWeekly?: boolean
   accountsByProvider?: AccountsByProvider
+  selectedByProvider?: SelectedAccounts
 }): TrayPrimaryBar[] {
   const {
     pluginsMeta,
@@ -63,6 +64,7 @@ export function getTrayPrimaryBars(args: {
     pluginId,
     preferWeekly = false,
     accountsByProvider = {},
+    selectedByProvider = {},
   } = args
   if (!pluginSettings) return []
 
@@ -84,7 +86,7 @@ export function getTrayPrimaryBars(args: {
     // provider is intentionally skipped.
     if (!meta.primaryCandidates || meta.primaryCandidates.length === 0) continue
 
-    const state = pluginStates[resolveTrayStateKey(id, accountsByProvider)]
+    const state = pluginStates[resolveTrayStateKey(id, accountsByProvider, selectedByProvider)]
     const data = state?.data ?? null
 
     let fraction: number | undefined
@@ -156,6 +158,7 @@ export function getTrayWeeklyFraction(args: {
   pluginStates: Record<string, PluginState | undefined>
   displayMode?: DisplayMode
   accountsByProvider?: AccountsByProvider
+  selectedByProvider?: SelectedAccounts
 }): number | undefined {
   const {
     pluginId,
@@ -164,6 +167,7 @@ export function getTrayWeeklyFraction(args: {
     pluginStates,
     displayMode = DEFAULT_DISPLAY_MODE,
     accountsByProvider = {},
+    selectedByProvider = {},
   } = args
   if (!pluginSettings) return undefined
   if (pluginSettings.disabled.includes(pluginId)) return undefined
@@ -172,7 +176,7 @@ export function getTrayWeeklyFraction(args: {
   const weeklyLabel = meta?.weeklyCandidate
   if (!weeklyLabel) return undefined
 
-  const data = pluginStates[resolveTrayStateKey(pluginId, accountsByProvider)]?.data ?? null
+  const data = pluginStates[resolveTrayStateKey(pluginId, accountsByProvider, selectedByProvider)]?.data ?? null
   if (!data) return undefined
 
   const metricLine = data.lines.find(
@@ -220,6 +224,7 @@ export function getTrayMultiProviderMetrics(args: {
   pluginStates: Record<string, PluginState | undefined>
   displayMode?: DisplayMode
   accountsByProvider?: AccountsByProvider
+  selectedByProvider?: SelectedAccounts
 }): TrayMultiProviderMetrics {
   const {
     pluginId,
@@ -228,6 +233,7 @@ export function getTrayMultiProviderMetrics(args: {
     pluginStates,
     displayMode = DEFAULT_DISPLAY_MODE,
     accountsByProvider = {},
+    selectedByProvider = {},
   } = args
   if (!pluginSettings) return {}
   if (pluginSettings.disabled.includes(pluginId)) return {}
@@ -235,7 +241,7 @@ export function getTrayMultiProviderMetrics(args: {
   const meta = pluginsMeta.find((p) => p.id === pluginId)
   const multiTrayLines = meta?.multiTrayLines ?? []
   if (multiTrayLines.length > 0) {
-    const data = pluginStates[resolveTrayStateKey(pluginId, accountsByProvider)]?.data ?? null
+    const data = pluginStates[resolveTrayStateKey(pluginId, accountsByProvider, selectedByProvider)]?.data ?? null
     return {
       sessionFraction: multiTrayLines[0]
         ? getProgressLineFraction(data, multiTrayLines[0], displayMode)
@@ -255,6 +261,7 @@ export function getTrayMultiProviderMetrics(args: {
     pluginId,
     preferWeekly: false,
     accountsByProvider,
+    selectedByProvider,
   })[0]?.fraction
 
   const weeklyFraction = getTrayWeeklyFraction({
@@ -264,6 +271,7 @@ export function getTrayMultiProviderMetrics(args: {
     pluginStates,
     displayMode,
     accountsByProvider,
+    selectedByProvider,
   })
 
   return { sessionFraction, weeklyFraction }

--- a/src/pages/overview.test.tsx
+++ b/src/pages/overview.test.tsx
@@ -1,129 +1,55 @@
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { describe, expect, it } from "vitest"
 import { OverviewPage } from "@/pages/overview"
+import type { GroupedProviderView } from "@/hooks/app/group-provider-views"
 
-vi.mock("@/components/models-today-strip", () => ({
-  ModelsTodayStrip: () => <div data-testid="models-today-strip-mock" />,
-}))
-
-describe("OverviewPage", () => {
-  it("renders empty state", () => {
-    render(<OverviewPage plugins={[]} displayMode="used" resetTimerDisplayMode="relative" />)
-    expect(screen.getByText("No providers enabled")).toBeInTheDocument()
+function view(): GroupedProviderView {
+  const acct = (label: string, plan: string) => ({
+    accountId: label.toLowerCase(),
+    label,
+    data: {
+      providerId: "claude",
+      accountId: label.toLowerCase(),
+      displayName: "Claude",
+      plan,
+      lines: [],
+      iconUrl: "",
+    },
+    loading: false,
+    error: null,
+    lastManualRefreshAt: null,
+    lastUpdatedAt: 1,
   })
+  return {
+    meta: {
+      id: "claude",
+      name: "Claude",
+      iconUrl: "",
+      brandColor: null,
+      lines: [],
+      links: [],
+      primaryCandidates: [],
+      weeklyCandidate: null,
+      multiTrayLines: [],
+      trayPrimaryLabel: null,
+      detected: true,
+    },
+    accounts: [acct("Work", "Max"), acct("Home", "Pro")],
+  }
+}
 
-  it("renders provider cards", () => {
-    const plugins = [
-      {
-        meta: { id: "a", name: "Alpha", iconUrl: "icon", lines: [] },
-        data: { providerId: "a", displayName: "Alpha", lines: [], iconUrl: "icon" },
-        loading: false,
-        error: null,
-        lastManualRefreshAt: null,
-        lastUpdatedAt: null,
-      },
-    ]
-    render(<OverviewPage plugins={plugins} displayMode="used" resetTimerDisplayMode="relative" />)
-    expect(screen.getByText("Alpha")).toBeInTheDocument()
-  })
-
-  it("only shows overview-scoped lines", () => {
-    const plugins = [
-      {
-        meta: {
-          id: "test",
-          name: "Test",
-          iconUrl: "icon",
-          lines: [
-            { type: "text" as const, label: "Primary", scope: "overview" as const },
-            { type: "text" as const, label: "Secondary", scope: "detail" as const },
-          ],
-        },
-        data: {
-          providerId: "test",
-          displayName: "Test",
-          lines: [
-            { type: "text" as const, label: "Primary", value: "Shown" },
-            { type: "text" as const, label: "Secondary", value: "Hidden" },
-          ],
-          iconUrl: "icon",
-        },
-        loading: false,
-        error: null,
-        lastManualRefreshAt: null,
-        lastUpdatedAt: null,
-      },
-    ]
-    render(<OverviewPage plugins={plugins} displayMode="used" resetTimerDisplayMode="relative" />)
-    expect(screen.getByText("Primary")).toBeInTheDocument()
-    expect(screen.getByText("Shown")).toBeInTheDocument()
-    expect(screen.queryByText("Secondary")).not.toBeInTheDocument()
-    expect(screen.queryByText("Hidden")).not.toBeInTheDocument()
-  })
-
-  it("does not show provider quick links in combined view", () => {
-    const plugins = [
-      {
-        meta: {
-          id: "alpha",
-          name: "Alpha",
-          iconUrl: "icon",
-          lines: [],
-          links: [{ label: "Status", url: "https://status.example.com" }],
-        },
-        data: { providerId: "alpha", displayName: "Alpha", lines: [], iconUrl: "icon" },
-        loading: false,
-        error: null,
-        lastManualRefreshAt: null,
-        lastUpdatedAt: null,
-      },
-    ]
-
-    render(<OverviewPage plugins={plugins} displayMode="used" resetTimerDisplayMode="relative" />)
-    expect(screen.queryByRole("button", { name: /status/i })).toBeNull()
-  })
-
-  it("renders the models-today strip when providers are enabled", () => {
-    const plugins = [
-      {
-        meta: { id: "a", name: "Alpha", iconUrl: "icon", lines: [] },
-        data: { providerId: "a", displayName: "Alpha", lines: [], iconUrl: "icon" },
-        loading: false,
-        error: null,
-        lastManualRefreshAt: null,
-        lastUpdatedAt: null,
-      },
-    ]
-    render(<OverviewPage plugins={plugins} displayMode="used" resetTimerDisplayMode="relative" />)
-    expect(screen.getByText("Quick Usage Overview")).toBeInTheDocument()
-    expect(screen.getByTestId("models-today-strip-mock")).toBeInTheDocument()
-  })
-
-  it("hides the strip when overview spend strip is disabled", () => {
-    const plugins = [
-      {
-        meta: { id: "a", name: "Alpha", iconUrl: "icon", lines: [] },
-        data: { providerId: "a", displayName: "Alpha", lines: [], iconUrl: "icon" },
-        loading: false,
-        error: null,
-        lastManualRefreshAt: null,
-        lastUpdatedAt: null,
-      },
-    ]
+describe("OverviewPage multi-account", () => {
+  it("renders one card per provider with account dots", () => {
     render(
       <OverviewPage
-        plugins={plugins}
+        plugins={[]}
+        groupedPlugins={[view()]}
         displayMode="used"
         resetTimerDisplayMode="relative"
         overviewSpendStripEnabled={false}
       />
     )
-    expect(screen.queryByText("Quick Usage Overview")).not.toBeInTheDocument()
-    expect(screen.queryByTestId("models-today-strip-mock")).not.toBeInTheDocument()
-  })
-
-  it("does not render the strip in the empty state", () => {
-    render(<OverviewPage plugins={[]} displayMode="used" resetTimerDisplayMode="relative" />)
-    expect(screen.queryByTestId("models-today-strip-mock")).not.toBeInTheDocument()
+    expect(screen.getAllByRole("tab")).toHaveLength(2)
+    expect(screen.getByText("Claude")).toBeInTheDocument()
   })
 })

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -1,10 +1,15 @@
 import { ModelsTodayStrip } from "@/components/models-today-strip"
 import { ProviderCard } from "@/components/provider-card"
+import type { GroupedProviderView } from "@/hooks/app/group-provider-views"
 import type { PluginDisplayState } from "@/lib/plugin-types"
 import type { DisplayMode, ResetTimerDisplayMode, TimeFormatMode } from "@/lib/settings"
 
 interface OverviewPageProps {
+  /** Flat, first-account-per-provider state — drives the spend strip only. */
   plugins: PluginDisplayState[]
+  /** One entry per provider carrying its ordered account snapshots — drives the
+   * paginated cards. */
+  groupedPlugins: GroupedProviderView[]
   onRetryPlugin?: (pluginId: string) => void
   displayMode: DisplayMode
   resetTimerDisplayMode: ResetTimerDisplayMode
@@ -16,6 +21,7 @@ interface OverviewPageProps {
 
 export function OverviewPage({
   plugins,
+  groupedPlugins,
   onRetryPlugin,
   displayMode,
   resetTimerDisplayMode,
@@ -26,7 +32,7 @@ export function OverviewPage({
 }: OverviewPageProps) {
   return (
     <div className="pb-3">
-      {plugins.length === 0 ? (
+      {groupedPlugins.length === 0 ? (
         <div className="text-center text-muted-foreground py-8">
           No providers enabled
         </div>
@@ -38,22 +44,17 @@ export function OverviewPage({
               <ModelsTodayStrip plugins={plugins} />
             </section>
           )}
-          {plugins.map((plugin, index) => (
+          {groupedPlugins.map((group, index) => (
             <ProviderCard
-              key={plugin.meta.id}
-              name={plugin.meta.name}
-              plan={plugin.data?.plan ?? undefined}
+              key={group.meta.id}
+              name={group.meta.name}
               asCard
-              iconUrl={plugin.meta.iconUrl}
-              pluginId={plugin.meta.id}
-              showSeparator={index < plugins.length - 1}
-              loading={plugin.loading}
-              error={plugin.error}
-              lines={plugin.data?.lines ?? []}
-              skeletonLines={plugin.meta.lines}
-              lastManualRefreshAt={plugin.lastManualRefreshAt}
-              lastUpdatedAt={plugin.lastUpdatedAt}
-              onRetry={onRetryPlugin ? () => onRetryPlugin(plugin.meta.id) : undefined}
+              iconUrl={group.meta.iconUrl}
+              pluginId={group.meta.id}
+              showSeparator={index < groupedPlugins.length - 1}
+              skeletonLines={group.meta.lines}
+              accounts={group.accounts}
+              onRetry={onRetryPlugin ? () => onRetryPlugin(group.meta.id) : undefined}
               scopeFilter="overview"
               displayMode={displayMode}
               resetTimerDisplayMode={resetTimerDisplayMode}

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -11,6 +11,8 @@ interface OverviewPageProps {
    * paginated cards. */
   groupedPlugins: GroupedProviderView[]
   onRetryPlugin?: (pluginId: string) => void
+  /** Persist the account a provider shows (card + tray follow it). */
+  onSelectAccount?: (providerId: string, accountId: string) => void
   displayMode: DisplayMode
   resetTimerDisplayMode: ResetTimerDisplayMode
   timeFormatMode?: TimeFormatMode
@@ -23,6 +25,7 @@ export function OverviewPage({
   plugins,
   groupedPlugins,
   onRetryPlugin,
+  onSelectAccount,
   displayMode,
   resetTimerDisplayMode,
   timeFormatMode = "auto",
@@ -54,6 +57,15 @@ export function OverviewPage({
               showSeparator={index < groupedPlugins.length - 1}
               skeletonLines={group.meta.lines}
               accounts={group.accounts}
+              activeIndex={group.activeIndex}
+              onActiveIndexChange={
+                onSelectAccount
+                  ? (i) => {
+                      const accountId = group.accounts[i]?.accountId
+                      if (accountId) onSelectAccount(group.meta.id, accountId)
+                    }
+                  : undefined
+              }
               onRetry={onRetryPlugin ? () => onRetryPlugin(group.meta.id) : undefined}
               scopeFilter="overview"
               displayMode={displayMode}

--- a/src/pages/provider-detail.tsx
+++ b/src/pages/provider-detail.tsx
@@ -8,6 +8,10 @@ interface ProviderDetailPageProps {
   /** Ordered account snapshots for the selected provider — drives the paginated
    * card. Falls back to `plugin`'s flat state when absent (single account). */
   accounts?: AccountSnapshot[]
+  /** Index into `accounts` of the persisted selection (primary as fallback). */
+  activeIndex?: number
+  /** Persist the account this provider shows (card + tray follow it). */
+  onSelectAccount?: (providerId: string, accountId: string) => void
   onRetry?: () => void
   displayMode: DisplayMode
   resetTimerDisplayMode: ResetTimerDisplayMode
@@ -19,6 +23,8 @@ interface ProviderDetailPageProps {
 export function ProviderDetailPage({
   plugin,
   accounts,
+  activeIndex,
+  onSelectAccount,
   onRetry,
   displayMode,
   resetTimerDisplayMode,
@@ -41,6 +47,15 @@ export function ProviderDetailPage({
       showSeparator={false}
       skeletonLines={plugin.meta.lines}
       accounts={accounts}
+      activeIndex={activeIndex}
+      onActiveIndexChange={
+        onSelectAccount
+          ? (i) => {
+              const accountId = accounts?.[i]?.accountId
+              if (accountId) onSelectAccount(plugin.meta.id, accountId)
+            }
+          : undefined
+      }
       onRetry={onRetry}
       scopeFilter="all"
       displayMode={displayMode}

--- a/src/pages/provider-detail.tsx
+++ b/src/pages/provider-detail.tsx
@@ -1,9 +1,13 @@
 import { ProviderCard } from "@/components/provider-card"
+import type { AccountSnapshot } from "@/hooks/app/group-provider-views"
 import type { PluginDisplayState } from "@/lib/plugin-types"
 import type { DisplayMode, ResetTimerDisplayMode, TimeFormatMode } from "@/lib/settings"
 
 interface ProviderDetailPageProps {
   plugin: PluginDisplayState | null
+  /** Ordered account snapshots for the selected provider — drives the paginated
+   * card. Falls back to `plugin`'s flat state when absent (single account). */
+  accounts?: AccountSnapshot[]
   onRetry?: () => void
   displayMode: DisplayMode
   resetTimerDisplayMode: ResetTimerDisplayMode
@@ -14,6 +18,7 @@ interface ProviderDetailPageProps {
 
 export function ProviderDetailPage({
   plugin,
+  accounts,
   onRetry,
   displayMode,
   resetTimerDisplayMode,
@@ -32,15 +37,10 @@ export function ProviderDetailPage({
   return (
     <ProviderCard
       name={plugin.meta.name}
-      plan={plugin.data?.plan ?? undefined}
       links={plugin.meta.links}
       showSeparator={false}
-      loading={plugin.loading}
-      error={plugin.error}
-      lines={plugin.data?.lines ?? []}
       skeletonLines={plugin.meta.lines}
-      lastManualRefreshAt={plugin.lastManualRefreshAt}
-      lastUpdatedAt={plugin.lastUpdatedAt}
+      accounts={accounts}
       onRetry={onRetry}
       scopeFilter="all"
       displayMode={displayMode}


### PR DESCRIPTION
## Per-provider account cards UI + persisted account selection

Renders each provider as a **dotted, swipeable card** on the overview and detail pages, one dot/page per registered account, and unifies "which account is shown" into a **single persisted per-provider selection** that both the card and the menubar tray follow.

Stacks on the Plan 2 PR (`feat/multi-account-registry`), which provides the `accounts` settings store, `useAccounts()` hook, and `providerId::accountId` composite state keying. Base is that branch. Sibling of Plan 4 (#40).

### What it does

1. **Grouped per-provider account snapshots** — `group-provider-views` maps composite-keyed `pluginStates` into one snapshot per registered account (providers with none yield a single unnamed snapshot, so the single-account path is unchanged), and exposes an `activeIndex` resolved from the persisted selection.

2. **Swipe-to-page + card dots** — `provider-card-swipe` + pointer hook; the card renders one dot per account, the active account's label, and switches on tap/swipe.

3. **Cards on overview + detail** — both pages render the grouped cards.

4. **Persisted per-provider selection** *(the design chosen for the tray)* — a new `selectedAccounts` store (`providerId -> accountId`). The card opens to it, swiping persists the new choice, and the tray reads the **same** value via the shared `resolveSelectedAccountId` (persisted selection when it still names a registered account, else the primary lowest-`order` account). So "active" and "primary" are one deliberate, restart-stable choice rather than two diverging notions.

5. **Tray follows the selection** — `resolveTrayStateKey` + the tray state lookups take `selectedByProvider`. Probe/cache state is keyed `providerId::accountId`, so before this the tray read the empty bare `providerId` key and blanked the menubar for multi-account providers. With no registered accounts it falls back to the bare `providerId` — single-account behavior is byte-for-byte unchanged.

### Tests

`npx vitest run` → **111 files, 1864 passed**. `npx tsc --noEmit` clean. Coverage added: `resolveSelectedAccountId` (settings), `activeIndex` resolution (group-provider-views), `resolveTrayStateKey` + tray-preview follow-the-selection cases (use-tray-icon), plus the existing card/swipe/overview suites.

### Notes

- The tray→account routing task began as a failing TDD unit test the Plan 3 workflow agent left when it died mid-run (computer sleep); it's now implemented, wired, and (per the follow-up decision) upgraded from "primary account" to the persisted selection.
- Removing a currently-selected account leaves a stale `selectedAccounts` entry; `resolveSelectedAccountId` falls back to primary so behavior is correct — pruning the entry on removal is a minor follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)