### PR TITLE
fix(updater): force a fresh instance on relaunch after update

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -261,23 +261,36 @@ fn macos_bundle_path(exe: &std::path::Path) -> Option<std::path::PathBuf> {
 /// then `open`s the bundle, yielding a single clean instance. If the bundle
 /// path can't be resolved we fall back to a plain exit (matching the old
 /// failure mode rather than risking a stuck process).
+///
+/// `open -n` (new instance) is deliberate: right after this process dies,
+/// LaunchServices can still consider the bundle "running" and answer a plain
+/// `open` by doing nothing, so the app intermittently never comes back.
+/// Forcing a fresh instance sidesteps that race.
 #[tauri::command]
 #[specta::specta]
 fn relaunch_app(app_handle: tauri::AppHandle) {
     #[cfg(target_os = "macos")]
     {
-        if let Ok(exe) = std::env::current_exe() {
-            if let Some(bundle) = macos_bundle_path(&exe) {
-                let pid = std::process::id();
-                let script = format!(
-                    "while /bin/kill -0 {pid} 2>/dev/null; do sleep 0.1; done; exec /usr/bin/open \"{}\"",
-                    bundle.display()
-                );
-                let _ = std::process::Command::new("/bin/sh")
-                    .arg("-c")
-                    .arg(script)
-                    .spawn();
-            }
+        match std::env::current_exe() {
+            Ok(exe) => match macos_bundle_path(&exe) {
+                Some(bundle) => {
+                    let pid = std::process::id();
+                    let script = format!(
+                        "while /bin/kill -0 {pid} 2>/dev/null; do sleep 0.1; done; exec /usr/bin/open -n \"{}\"",
+                        bundle.display()
+                    );
+                    match std::process::Command::new("/bin/sh")
+                        .arg("-c")
+                        .arg(script)
+                        .spawn()
+                    {
+                        Ok(_) => log::info!("relaunch scheduled for {}", bundle.display()),
+                        Err(error) => log::error!("failed to spawn relaunch helper: {error}"),
+                    }
+                }
+                None => log::warn!("relaunch skipped: no .app bundle for {exe:?}"),
+            },
+            Err(error) => log::warn!("relaunch skipped: could not resolve current exe: {error}"),
         }
     }
     app_handle.exit(0);

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -23,6 +23,11 @@ export const commands = {
 	 *  then `open`s the bundle, yielding a single clean instance. If the bundle
 	 *  path can't be resolved we fall back to a plain exit (matching the old
 	 *  failure mode rather than risking a stuck process).
+	 * 
+	 *  `open -n` (new instance) is deliberate: right after this process dies,
+	 *  LaunchServices can still consider the bundle "running" and answer a plain
+	 *  `open` by doing nothing, so the app intermittently never comes back.
+	 *  Forcing a fresh instance sidesteps that race.
 	 */
 	relaunchApp: () => __TAURI_INVOKE<void>("relaunch_app"),
 	startProbeBatch: (batchId: string | null, pluginIds: string[] | null) => typedError<ProbeBatchStarted, string>(__TAURI_INVOKE("start_probe_batch", { batchId, pluginIds })),


### PR DESCRIPTION
## What

Fixes the intermittent "updated, quit, but didn't relaunch" bug.

The relaunch helper (`relaunch_app` in `src-tauri/src/lib.rs`) runs `open "<bundle>"` from a detached shell once the process exits. Right after exit, LaunchServices can still consider the bundle "running" and answer a plain `open` by doing nothing — so the app intermittently never comes back (usually works, occasionally doesn't).

## Fix

- `open -n` (force a new instance) sidesteps LaunchServices' stale "already running" state.
- The helper now logs the resolved bundle path / spawn result instead of swallowing every error with `let _ =`.

## Verification

- `cargo test`: 199 passed
- `bindings.ts` regenerated (doc comment only)

No frontend change; the fix is entirely in the relaunch command.