### PR TITLE
fix(accounts): multiple accounts refresh

### DIFF
--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -10,7 +10,8 @@ The server starts automatically with the app. If the port is already in use, the
 
 ### `GET /v1/usage`
 
-Returns an array of cached usage snapshots for all **enabled** providers, ordered by your plugin settings.
+Returns cached usage snapshots for all **enabled** providers, ordered by plugin settings and
+then by account. A provider can appear more than once when it has added accounts.
 
 - **200 OK** — JSON array (may be empty `[]` if no cached data exists yet).
 
@@ -33,6 +34,7 @@ Unknown routes return **404 Not Found**.
 ```json
 {
   "providerId": "claude",
+  "accountId": "work",
   "displayName": "Claude",
   "plan": "Team 5x",
   "lines": [
@@ -70,15 +72,19 @@ Unknown routes return **404 Not Found**.
 
 The `lines` array uses the same metric line types as the internal plugin output: `progress`, `text`, `badge`, and `barChart`.
 
+`accountId` identifies an added account. It is `null` for the provider's Default account.
+
 `fetchedAt` is an ISO 8601 timestamp indicating when the snapshot was last successfully fetched.
 
 `iconUrl` is intentionally omitted from the API response to keep payloads small.
 
 ## Filtering and Caching Behavior
 
-- The collection endpoint (`/v1/usage`) returns **enabled providers only**, in the order defined by your plugin settings.
+- The collection endpoint (`/v1/usage`) returns **enabled providers only**. Each provider's
+  Default snapshot, when available, comes first, followed by its added accounts in their saved order.
 - Only **successful** probe results are cached. A failed probe never overwrites a previous successful snapshot.
-- The single-provider endpoint (`/v1/usage/:providerId`) works for any known provider, including disabled ones.
+- The single-provider endpoint (`/v1/usage/:providerId`) returns the Default account and works
+  for any known provider, including disabled ones.
 
 ## CORS
 

--- a/src-tauri/src/accounts.rs
+++ b/src-tauri/src/accounts.rs
@@ -27,15 +27,19 @@ struct AccountsSettingsFile {
     accounts: Option<HashMap<String, Vec<AccountMeta>>>,
 }
 
+pub(crate) fn parse_settings_accounts(text: &str) -> HashMap<String, Vec<AccountMeta>> {
+    let Ok(parsed) = serde_json::from_str::<AccountsSettingsFile>(text) else {
+        return HashMap::new();
+    };
+    parsed.accounts.unwrap_or_default()
+}
+
 pub(crate) fn read_settings_accounts(app_data_dir: &Path) -> HashMap<String, Vec<AccountMeta>> {
     let path = app_data_dir.join("settings.json");
     let Ok(text) = std::fs::read_to_string(path) else {
         return HashMap::new();
     };
-    let Ok(parsed) = serde_json::from_str::<AccountsSettingsFile>(&text) else {
-        return HashMap::new();
-    };
-    parsed.accounts.unwrap_or_default()
+    parse_settings_accounts(&text)
 }
 
 fn config_accounts_dir(provider_id: &str) -> Option<PathBuf> {

--- a/src-tauri/src/local_http_api/cache.rs
+++ b/src-tauri/src/local_http_api/cache.rs
@@ -302,13 +302,8 @@ struct PluginSettingsJson {
     disabled: Option<Vec<String>>,
 }
 
-fn read_plugin_settings(app_data_dir: &Path) -> (Vec<String>, HashSet<String>, bool) {
-    let path = app_data_dir.join(SETTINGS_FILE_NAME);
-    let data = match std::fs::read_to_string(&path) {
-        Ok(d) => d,
-        Err(_) => return (Vec::new(), HashSet::new(), false),
-    };
-    match serde_json::from_str::<SettingsFile>(&data) {
+fn parse_plugin_settings(data: &str) -> (Vec<String>, HashSet<String>, bool) {
+    match serde_json::from_str::<SettingsFile>(data) {
         Ok(sf) => {
             let ps = sf.plugins.unwrap_or(PluginSettingsJson {
                 order: None,
@@ -321,6 +316,14 @@ fn read_plugin_settings(app_data_dir: &Path) -> (Vec<String>, HashSet<String>, b
         }
         Err(_) => (Vec::new(), HashSet::new(), false),
     }
+}
+
+fn read_plugin_settings(app_data_dir: &Path) -> (Vec<String>, HashSet<String>, bool) {
+    let path = app_data_dir.join(SETTINGS_FILE_NAME);
+    let Ok(data) = std::fs::read_to_string(path) else {
+        return (Vec::new(), HashSet::new(), false);
+    };
+    parse_plugin_settings(&data)
 }
 
 /// Minimal struct for reading just the auto-update interval, isolated from
@@ -355,13 +358,13 @@ pub fn read_auto_update_interval_minutes(app_data_dir: &Path) -> u64 {
 /// unless explicitly disabled (or, with no stored settings, only detected
 /// plugins are enabled — detected means the provider's credentials/config were
 /// found on this machine).
-fn enabled_ids_for(
-    app_data_dir: &Path,
+fn enabled_ids_from_settings(
+    settings_order: &[String],
+    disabled: &HashSet<String>,
+    has_settings: bool,
     known_plugin_ids: &[String],
     detected_ids: &HashSet<String>,
 ) -> Vec<String> {
-    let (settings_order, disabled, has_settings) = read_plugin_settings(app_data_dir);
-
     let is_enabled = |id: &str| -> bool {
         if has_settings {
             !disabled.contains(id)
@@ -373,7 +376,7 @@ fn enabled_ids_for(
     // Build ordered plugin ids: settings order first, then remaining known ids.
     let mut ordered: Vec<String> = Vec::new();
     let mut seen = HashSet::new();
-    for id in &settings_order {
+    for id in settings_order {
         if seen.insert(id.clone()) {
             ordered.push(id.clone());
         }
@@ -385,6 +388,21 @@ fn enabled_ids_for(
     }
 
     ordered.into_iter().filter(|id| is_enabled(id)).collect()
+}
+
+fn enabled_ids_for(
+    app_data_dir: &Path,
+    known_plugin_ids: &[String],
+    detected_ids: &HashSet<String>,
+) -> Vec<String> {
+    let (settings_order, disabled, has_settings) = read_plugin_settings(app_data_dir);
+    enabled_ids_from_settings(
+        &settings_order,
+        &disabled,
+        has_settings,
+        known_plugin_ids,
+        detected_ids,
+    )
 }
 
 /// Public wrapper for the native scheduler to learn which plugins to probe.
@@ -407,10 +425,40 @@ pub fn enabled_usage_snapshots() -> Vec<CachedPluginSnapshot> {
 
 /// Build the ordered list of enabled cached snapshots for GET /v1/usage.
 pub(super) fn enabled_snapshots_ordered(state: &CacheState) -> Vec<CachedPluginSnapshot> {
-    enabled_ids_for(&state.app_data_dir, &state.known_plugin_ids, &state.detected_ids)
-        .into_iter()
-        .filter_map(|id| state.snapshots.get(&id).cloned())
-        .collect()
+    let settings = std::fs::read_to_string(state.app_data_dir.join(SETTINGS_FILE_NAME)).ok();
+    let (settings_order, disabled, has_settings) = settings
+        .as_deref()
+        .map(parse_plugin_settings)
+        .unwrap_or_else(|| (Vec::new(), HashSet::new(), false));
+    let mut accounts = settings
+        .as_deref()
+        .map(crate::accounts::parse_settings_accounts)
+        .unwrap_or_default();
+    let mut snapshots = Vec::new();
+
+    for provider_id in enabled_ids_from_settings(
+        &settings_order,
+        &disabled,
+        has_settings,
+        &state.known_plugin_ids,
+        &state.detected_ids,
+    ) {
+        if let Some(snapshot) = state.snapshots.get(&provider_id) {
+            snapshots.push(snapshot.clone());
+        }
+
+        if let Some(mut provider_accounts) = accounts.remove(&provider_id) {
+            provider_accounts.sort_by_key(|account| account.order);
+            snapshots.extend(provider_accounts.into_iter().filter_map(|account| {
+                state
+                    .snapshots
+                    .get(&cache_key(&provider_id, Some(&account.account_id)))
+                    .cloned()
+            }));
+        }
+    }
+
+    snapshots
 }
 
 #[cfg(test)]
@@ -510,6 +558,56 @@ mod tests {
             );
             std::thread::sleep(Duration::from_millis(5));
         }
+    }
+
+    #[test]
+    fn enabled_snapshots_include_each_configured_account_in_order() {
+        let dir = temp_dir("enabled-account-snapshots");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(SETTINGS_FILE_NAME),
+            r#"{
+                "plugins":{"order":["claude"],"disabled":[]},
+                "accounts":{"claude":[
+                    {"accountId":"home","label":"Home","order":1},
+                    {"accountId":"work","label":"Work","order":0}
+                ]}
+            }"#,
+        )
+        .unwrap();
+
+        let mut default = make_snapshot("claude", "Default");
+        default.account_id = None;
+        let mut work = make_snapshot("claude", "Work");
+        work.account_id = Some("work".to_string());
+        let mut home = make_snapshot("claude", "Home");
+        home.account_id = Some("home".to_string());
+        let mut removed = make_snapshot("claude", "Removed");
+        removed.account_id = Some("removed".to_string());
+
+        let state = CacheState {
+            snapshots: HashMap::from([
+                ("claude".to_string(), default),
+                ("claude::work".to_string(), work),
+                ("claude::home".to_string(), home),
+                ("claude::removed".to_string(), removed),
+            ]),
+            app_data_dir: dir.clone(),
+            known_plugin_ids: vec!["claude".to_string()],
+            detected_ids: HashSet::new(),
+            dirty_generation: 0,
+            flushed_generation: 0,
+            flush_scheduled: false,
+        };
+
+        let snapshots = enabled_snapshots_ordered(&state);
+        let account_ids: Vec<_> = snapshots
+            .iter()
+            .map(|snapshot| snapshot.account_id.as_deref())
+            .collect();
+        assert_eq!(account_ids, vec![None, Some("work"), Some("home")]);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Automatic refresh successfully cached named accounts under keys such as claude::work, but cache hydration only looked up the bare provider key, claude.

This change reads the current account roster from one settings snapshot and returns each configured account in deterministic order. It also filters stale cache entries for removed accounts and fixes both UI hydration and GET /v1/usage.

#### Bug explanation

Previous cache read contained composite keys:

```
cache HashMap

"claude::work" ──▶ Work snapshot
"claude::home" ──▶ Home snapshot
```

But `enabled_snapshots_ordered()` iterated only provider IDs:
```
enabled provider IDs
        │
        ▼
    ["claude"]
        │
        ▼
snapshots.get("claude")
        │
        ▼
       miss
        │
        ▼
return no Claude snapshots
```
This caused the full sequence:
time 

```
─────────────────────────────────────────────────────────▶

T0          T1              T2              T3
timer       probes finish   cache updated   UI hydrates
 │                │               │               │
 ▼                ▼               ▼               ▼
scheduler    Work + Home     composite keys   bare key lookup
                                                   │
                                                   ▼
                                             empty result

Backend data is fresh                         UI stays stale
```

#### Fix explanation

The cache reader now combines three data sets:

```

A. Provider settings
   order: [claude, codex]

B. Account metadata
   claude: [work(order 0), home(order 1)]

C. Cached snapshots
   claude
   claude::work
   claude::home
   claude::removed
```
It performs an ordered lookup rather than iterating every cache entry:
```
Provider order                Account order
     │                             │
     ▼                             ▼
  claude                    Default, work, home
     │                             │
     └──────────────┬──────────────┘
                    ▼
            expected cache keys
                    │
        ┌───────────┼──────────────┐
        ▼           ▼              ▼
     claude    claude::work   claude::home
        │           │              │
        └───────────┼──────────────┘
                    ▼
            ordered snapshots
```

Removed accounts now don't get updates because successful snapshots remain cached after an account is removed. The code does not have to delete the old cache entry immediately. It only exposes keys belonging to the current account roster.

**The single-provider HTTP route remains a Default-account lookup because its URL contains only a provider ID, not an account ID.**

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Screenshots

### Old build
**Before update:**
<img width="719" height="1194" alt="image" src="https://github.com/user-attachments/assets/217443f1-e325-461a-82a8-e5e5185082a4" />

**After update:**
<img width="400" height="858" alt="image" src="https://github.com/user-attachments/assets/dd95a794-4222-4a95-bc27-789121991a08" />

### New build
**Before update**:
<img width="400" height="1152" alt="image" src="https://github.com/user-attachments/assets/33928fc7-f418-4b9b-9d47-6de2eaf2b0e0" />

**After update**:
<img width="400" height="1152" alt="image" src="https://github.com/user-attachments/assets/ff6f454b-ccd1-419a-afcf-8510b329f46e" />


## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification
