### PR TITLE
chore(github-copilot): update UI to represent credits usage, not percents

### DIFF
--- a/docs/providers/copilot.md
+++ b/docs/providers/copilot.md
@@ -65,10 +65,11 @@ X-Github-Api-Version: 2025-04-01
 ```
 
 Since usage-based billing (AI Credits), the `premium_interactions` pool is shown as **Credits**
-(percent used). When `percent_remaining` is absent it is derived from `remaining / entitlement`. A
-bucket that is `unlimited`, carries the `-1` entitlement/remaining sentinel, or has a `0` entitlement
-is suppressed rather than rendered as a misleading 0%. When `overage_permitted` is true, premium usage
-beyond the pool is surfaced as an **Extra Usage** count (`overage_count`).
+(credit count used or left, based on the display setting). The progress limit is the `entitlement`, and
+the used count is `entitlement - remaining`. A bucket that is `unlimited`, carries the `-1`
+entitlement/remaining sentinel, or has a `0` entitlement is suppressed. A positive `overage_count` is
+shown as **Additional Usage**, independently of the current `overage_permitted` setting because that
+permission can change after usage is consumed. Usage-based plans show credits; legacy plans show requests.
 
 ### Response (Free Tier)
 
@@ -92,8 +93,8 @@ beyond the pool is surfaced as an **Extra Usage** count (`overage_count`).
 
 | Line         | Tier | Description                                    |
 |--------------|------|------------------------------------------------|
-| Credits      | Paid | Premium interactions used (percent of pool)    |
-| Extra Usage  | Paid | Premium interactions beyond the pool (count)   |
+| Credits      | Paid | Premium interactions used or left (credit count) |
+| Additional Usage | Paid | Paid usage consumed beyond the included pool |
 | Chat         | Both | Chat messages used                             |
 | Completions  | Free | Code completions used                          |
 

--- a/plugins/copilot/plugin.js
+++ b/plugins/copilot/plugin.js
@@ -155,13 +155,33 @@
     });
   }
 
-  // "Extra Usage" — premium interactions consumed beyond the included Credits pool. Surfaced only once
-  // the user has enabled additional (overage) spend (`overage_permitted`); a real zero is then shown.
-  // No spending cap is exposed here, so this is an unbounded count, not a meter.
-  function overageLine(ctx, snapshot) {
-    if (!snapshot || typeof snapshot !== "object" || snapshot.overage_permitted !== true) return null;
-    const overage = Math.max(0, numOrNull(snapshot.overage_count) || 0);
-    return ctx.line.text({ label: "Extra Usage", value: String(overage) });
+  function creditsLine(ctx, snapshot, resetDate) {
+    if (!snapshot || typeof snapshot !== "object") return null;
+
+    const entitlement = numOrNull(snapshot.entitlement);
+    const remaining = numOrNull(snapshot.remaining) ?? numOrNull(snapshot.quota_remaining);
+
+    if (snapshot.unlimited === true || entitlement === -1 || remaining === -1) return null;
+    if (entitlement === null || entitlement <= 0 || remaining === null) return null;
+
+    return ctx.line.progress({
+      label: "Credits",
+      used: Math.max(0, entitlement - remaining),
+      limit: entitlement,
+      format: { kind: "count", suffix: "credits" },
+      resetsAt: ctx.util.toIso(resetDate),
+      periodDurationMs: 30 * 24 * 60 * 60 * 1000,
+    });
+  }
+
+  function overageLine(ctx, snapshot, tokenBasedBilling) {
+    if (!snapshot || typeof snapshot !== "object") return null;
+    const overage = numOrNull(snapshot.overage_count);
+    if (overage === null || overage <= 0) return null;
+
+    // Permission can change after usage accrues, so show consumed usage independently of it.
+    const unit = tokenBasedBilling === false ? "requests" : "credits";
+    return ctx.line.text({ label: "Additional Usage", value: String(overage) + " " + unit });
   }
 
   function makeLimitedProgressLine(ctx, label, remaining, total, resetDate) {
@@ -251,18 +271,21 @@
     }
 
     // Since usage-based billing (AI Credits), the metered premium pool is surfaced as "Credits", with
-    // "Extra Usage" carrying overage beyond it. Paid plans report Chat/Completions as the `-1`
+    // "Additional Usage" carrying overage beyond it. Paid plans report Chat/Completions as the `-1`
     // "unlimited" sentinel (suppressed); free plans carry real counts inside quota_snapshots (current)
     // or, on older responses, as limited_user_quotas against monthly_quotas below.
     const snapshots = data.quota_snapshots;
     const resetDate = data.quota_reset_date || data.limited_user_reset_date;
     if (snapshots) {
       const premium = snapshots.premium_interactions;
-      const creditsLine = snapshotLine(ctx, "Credits", premium, resetDate);
-      if (creditsLine) lines.push(creditsLine);
+      const premiumCreditsLine = creditsLine(ctx, premium, resetDate);
+      if (premiumCreditsLine) lines.push(premiumCreditsLine);
 
-      const extraLine = overageLine(ctx, premium);
-      if (extraLine) lines.push(extraLine);
+      const tokenBasedBilling = premium && typeof premium.token_based_billing === "boolean"
+        ? premium.token_based_billing
+        : data.token_based_billing;
+      const additionalUsageLine = overageLine(ctx, premium, tokenBasedBilling);
+      if (additionalUsageLine) lines.push(additionalUsageLine);
 
       const chatLine = snapshotLine(ctx, "Chat", snapshots.chat, resetDate);
       if (chatLine) lines.push(chatLine);

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -9,7 +9,7 @@
   "detect": [{ "file": "~/.config/gh/hosts.yml" }],
   "lines": [
     { "type": "progress", "label": "Credits", "scope": "overview", "primaryOrder": 1 },
-    { "type": "text", "label": "Extra Usage", "scope": "detail" },
+    { "type": "text", "label": "Additional Usage", "scope": "detail" },
     { "type": "progress", "label": "Chat", "scope": "overview", "primaryOrder": 2 },
     { "type": "progress", "label": "Completions", "scope": "overview" }
   ]

--- a/plugins/copilot/plugin.test.js
+++ b/plugins/copilot/plugin.test.js
@@ -173,8 +173,9 @@ describe("copilot plugin", () => {
     const premium = result.lines.find((l) => l.label === "Credits");
     const chat = result.lines.find((l) => l.label === "Chat");
     expect(premium).toBeTruthy();
-    expect(premium.used).toBe(20); // 100 - 80
-    expect(premium.limit).toBe(100);
+    expect(premium.used).toBe(60);
+    expect(premium.limit).toBe(300);
+    expect(premium.format).toEqual({ kind: "count", suffix: "credits" });
     expect(chat).toBeTruthy();
     expect(chat.used).toBe(5); // 100 - 95
   });
@@ -248,7 +249,7 @@ describe("copilot plugin", () => {
     expect(premium.resetsAt).toBe("2099-01-15T00:00:00.000Z");
   });
 
-  it("clamps usedPercent to 0 when percent_remaining > 100", async () => {
+  it("clamps used Credits to 0 when remaining exceeds entitlement", async () => {
     const ctx = makePluginTestContext();
     setKeychainToken(ctx, "tok");
     ctx.host.http.request.mockReturnValue({
@@ -527,8 +528,8 @@ describe("copilot plugin", () => {
     expect(result.lines[0].text).toBe("No usage data");
   });
 
-  describe("AI Credits + Extra Usage", () => {
-    it("derives Credits % from entitlement/remaining when percent_remaining is absent", async () => {
+  describe("AI Credits + Additional Usage", () => {
+    it("renders Credits as a count from entitlement and remaining", async () => {
       const ctx = makePluginTestContext();
       setKeychainToken(ctx, "tok");
       mockUsageOk(
@@ -543,7 +544,28 @@ describe("copilot plugin", () => {
       const result = plugin.probe(ctx);
       const credits = result.lines.find((l) => l.label === "Credits");
       expect(credits).toBeTruthy();
-      expect(credits.used).toBe(70); // 100 - (90/300)*100
+      expect(credits.used).toBe(210);
+      expect(credits.limit).toBe(300);
+      expect(credits.format).toEqual({ kind: "count", suffix: "credits" });
+    });
+
+    it("uses quota_remaining when remaining is absent", async () => {
+      const ctx = makePluginTestContext();
+      setKeychainToken(ctx, "tok");
+      mockUsageOk(
+        ctx,
+        makeUsageResponse({
+          quota_snapshots: {
+            premium_interactions: { entitlement: 300, quota_remaining: 90, quota_id: "premium" },
+          },
+        }),
+      );
+      const plugin = await loadPlugin();
+      const result = plugin.probe(ctx);
+      const credits = result.lines.find((l) => l.label === "Credits");
+      expect(credits.used).toBe(210);
+      expect(credits.limit).toBe(300);
+      expect(credits.format).toEqual({ kind: "count", suffix: "credits" });
     });
 
     it("suppresses Chat/Completions carrying the -1 unlimited sentinel (paid usage-based)", async () => {
@@ -582,7 +604,7 @@ describe("copilot plugin", () => {
       expect(result.lines.find((l) => l.label === "Credits")).toBeFalsy();
     });
 
-    it("adds an Extra Usage line only when overage is permitted", async () => {
+    it("shows positive Additional Usage as AI credits", async () => {
       const ctx = makePluginTestContext();
       setKeychainToken(ctx, "tok");
       mockUsageOk(
@@ -595,6 +617,7 @@ describe("copilot plugin", () => {
               remaining: 0,
               overage_permitted: true,
               overage_count: 42,
+              token_based_billing: true,
               quota_id: "premium",
             },
           },
@@ -602,13 +625,13 @@ describe("copilot plugin", () => {
       );
       const plugin = await loadPlugin();
       const result = plugin.probe(ctx);
-      const extra = result.lines.find((l) => l.label === "Extra Usage");
-      expect(extra).toBeTruthy();
-      expect(extra.type).toBe("text");
-      expect(extra.value).toBe("42");
+      const additional = result.lines.find((l) => l.label === "Additional Usage");
+      expect(additional).toBeTruthy();
+      expect(additional.type).toBe("text");
+      expect(additional.value).toBe("42 credits");
     });
 
-    it("omits Extra Usage when overage is not permitted", async () => {
+    it("shows consumed Additional Usage after overage permission is disabled", async () => {
       const ctx = makePluginTestContext();
       setKeychainToken(ctx, "tok");
       mockUsageOk(
@@ -619,6 +642,7 @@ describe("copilot plugin", () => {
               percent_remaining: 20,
               entitlement: 300,
               remaining: 60,
+              overage_permitted: false,
               overage_count: 5,
               quota_id: "premium",
             },
@@ -627,7 +651,51 @@ describe("copilot plugin", () => {
       );
       const plugin = await loadPlugin();
       const result = plugin.probe(ctx);
-      expect(result.lines.find((l) => l.label === "Extra Usage")).toBeFalsy();
+      expect(result.lines.find((l) => l.label === "Additional Usage").value).toBe("5 credits");
+    });
+
+    it("omits Additional Usage when none was consumed", async () => {
+      const ctx = makePluginTestContext();
+      setKeychainToken(ctx, "tok");
+      mockUsageOk(
+        ctx,
+        makeUsageResponse({
+          quota_snapshots: {
+            premium_interactions: {
+              entitlement: 300,
+              remaining: 60,
+              overage_permitted: true,
+              overage_count: 0,
+              quota_id: "premium",
+            },
+          },
+        }),
+      );
+      const plugin = await loadPlugin();
+      const result = plugin.probe(ctx);
+      expect(result.lines.find((l) => l.label === "Additional Usage")).toBeFalsy();
+    });
+
+    it("labels legacy overage as requests", async () => {
+      const ctx = makePluginTestContext();
+      setKeychainToken(ctx, "tok");
+      mockUsageOk(
+        ctx,
+        makeUsageResponse({
+          quota_snapshots: {
+            premium_interactions: {
+              entitlement: 300,
+              remaining: 0,
+              overage_count: 2,
+              token_based_billing: false,
+              quota_id: "premium",
+            },
+          },
+        }),
+      );
+      const plugin = await loadPlugin();
+      const result = plugin.probe(ctx);
+      expect(result.lines.find((l) => l.label === "Additional Usage").value).toBe("2 requests");
     });
   });
 


### PR DESCRIPTION
## Description

Since Github Copilot changed their pricing and now we use credits instead of % usage I think it's better to show user how much credits he has left to use.

Also hides additional usage panel if there is no actual additional usage.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Screenshots

<img width="400" height="323" alt="image" src="https://github.com/user-attachments/assets/1d3e821f-e09f-4655-8129-d742ab929fc5" />

<img width="400" height="367" alt="image" src="https://github.com/user-attachments/assets/a41c478d-9149-4b00-a193-298bb5fd7759" />

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification
