### PR TITLE
Feat/antigravity metrics

### DIFF
--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -265,6 +265,55 @@ if (ctx.host.fs.exists("~/.myapp/credentials.json")) {
 }
 ```
 
+## Local Language Server Discovery
+
+```typescript
+host.ls.discover(opts: {
+  processName: string,      // Executable name to match, e.g. "language_server"
+  markers: string[],        // Accepted --ide_name / --app_data_dir values; [] matches any
+  csrfFlag: string,         // Flag holding the CSRF token; "" when the process has none
+  portFlag?: string | null, // Flag holding a fallback port
+  extraFlags?: string[],    // Other flags to read out of the command line
+}): {
+  pid: number,
+  csrf: string,
+  ports: number[],          // TCP ports the process is listening on
+  extra: Record<string, string>,
+  extensionPort: number | null,
+} | null
+```
+
+Finds a locally running language server started by a provider's app, so a plugin can talk to it
+over localhost.
+
+### Behavior
+
+- **Cross-platform**: reads the process table and the kernel socket table directly, so it works on
+  macOS, Windows and Linux. On Unix an `lsof` sweep backs up the socket lookup.
+- **Returns `null`**: when no matching process is found. It never throws.
+- **Marker priority**: a process whose `--ide_name` or `--app_data_dir` matches a marker exactly is
+  preferred over one matched only by its path, which keeps sibling IDEs apart.
+- **Prefers a listening process**: apps often run several language-server children while only one
+  listens. A process with real listening sockets wins; one that only advertises `portFlag` is used
+  as a fallback and returned as `extensionPort`.
+- **Values change per restart**: the port and CSRF token are regenerated every time the app starts,
+  so discover on every probe rather than caching them.
+
+### Example
+
+```javascript
+const discovery = ctx.host.ls.discover({
+  processName: "language_server",
+  markers: ["antigravity", "antigravity-ide"],
+  csrfFlag: "--csrf_token",
+  portFlag: "--extension_server_port",
+})
+
+if (!discovery) throw "Start the app and try again."
+
+const port = discovery.ports[0] || discovery.extensionPort
+```
+
 ## SQLite
 
 ### Query (Read-Only)

--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -9,11 +9,19 @@ Antigravity is built on Codeium/Windsurf-derived infrastructure and uses the sam
 - **Vendor:** Google (internal codename "Jetski")
 - **Protocol:** Connect RPC v1 (JSON over HTTP) on local language server
 - **Service:** `exa.language_server_pb.LanguageServerService`
-- **Auth:** CSRF token from app/IDE process args; Google OAuth tokens from SQLite; `agy` token from macOS Keychain
+- **Auth:** CSRF token from app/IDE process args; Google OAuth tokens from SQLite; `agy` token from the macOS Keychain or its token file
 - **Quota:** fraction (0.0–1.0, where 1.0 = 100% remaining)
 - **Quota window:** 5 hours
 - **Timestamps:** ISO 8601
+- **Platforms:** macOS, Windows, Linux
 - **Requires:** Antigravity app/IDE running, signed-in app/IDE SQLite credentials, or `agy` signed in
+
+## What Antigravity Does Not Report
+
+Antigravity publishes a remaining-quota fraction per model and nothing else. There are **no token
+counts, no request counts and no costs** — not in the language server, not in the Cloud Code
+endpoints, and not in any local file the IDE or `agy` writes. UsagePal therefore shows no spend for
+this provider, and any dollar figure would be invented rather than measured.
 
 ## Discovery
 
@@ -21,13 +29,18 @@ The Antigravity app/IDE language server listens on a random localhost port. Thre
 
 ```bash
 # 1. Find process and extract CSRF token
+#    UsagePal reads the process table directly, which works the same on
+#    macOS, Windows and Linux. The shell equivalent on macOS/Linux is:
 ps -ax -o pid=,command= | grep -i '[l]anguage_server.*antigravity'
-# Process name: language_server, language_server_macos, or language_server_macos_arm
+# Process name: language_server plus a per-OS suffix —
+#   language_server_macos, language_server_macos_arm,
+#   language_server_linux_x64, language_server_windows_x64.exe
 # Match: --app_data_dir antigravity / antigravity-ide OR path contains /antigravity/
 # Extract: --csrf_token <token>
 # Extract: --extension_server_port <port>  (HTTP fallback)
 
 # 2. Find listening ports
+#    UsagePal reads the kernel socket table; lsof is only a fallback.
 lsof -nP -iTCP -sTCP:LISTEN -a -p <pid>
 
 # 3. Probe each port to find the Connect-RPC endpoint
@@ -35,6 +48,10 @@ POST https://127.0.0.1:<port>/.../GetUnleashData  → first 200 OK wins
 ```
 
 Port and CSRF token change on every app/IDE restart. The LS may use HTTPS with a self-signed cert.
+
+An IDE usually runs several language-server child processes and only one of them listens, so
+discovery prefers a process with real listening sockets and falls back to the process that
+advertises `--extension_server_port`.
 
 `agy` can also expose the same local service via an `agy` process. It has listening ports but no CSRF token or Antigravity marker flags, so discovery matches the `agy` executable directly.
 
@@ -161,10 +178,19 @@ Interestingly, non-Google models (Claude, GPT-OSS) are proxied through Codeium/W
 
 The Antigravity IDE stores auth credentials in VS Code-compatible state databases.
 
-- **Paths, tried in order:**
-  - `~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb`
-  - `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb`
+Antigravity IDE is a VS Code fork, so the database lives under the standard user-data directory for
+each OS. `Antigravity IDE` is the current folder name and `Antigravity` the pre-2.0 one, still
+present on machines that upgraded; both are tried, current first.
+
+- **Paths, by platform:**
+  - macOS: `~/Library/Application Support/Antigravity IDE|Antigravity/User/globalStorage/state.vscdb`
+  - Linux: `~/.config/Antigravity IDE|Antigravity/User/globalStorage/state.vscdb`
+  - Windows: `%APPDATA%\Antigravity IDE|Antigravity\User\globalStorage\state.vscdb`
 - **Table:** `ItemTable` (`key` TEXT, `value` TEXT)
+
+The same table also holds a cached `antigravityUnifiedStateSync.userStatus` blob. It is wrapped like
+the OAuth value but under a `userStatusSentinelKey` sentinel, and its payload carries no model
+display names — only unlabeled numbers — so UsagePal does not use it as an offline fallback.
 
 ### antigravityUnifiedStateSync.oauthToken (sentinel envelope → protobuf)
 
@@ -225,9 +251,20 @@ Base URLs tried in order:
 1. `https://daily-cloudcode-pa.googleapis.com`
 2. `https://cloudcode-pa.googleapis.com`
 
-### agy keychain fallback
+### agy credential fallback
 
-`agy` stores its auth in the macOS Keychain under service `gemini`, account `antigravity`. UsagePal reads that exact account only; it does not use legacy Gemini CLI files.
+`agy` caches its auth in the OS keyring — service `gemini`, account `antigravity`. UsagePal reads
+that exact account only; it does not use legacy Gemini CLI files.
+
+When the keyring is unavailable, `agy` falls back to a token file and drops a marker beside it:
+
+- Token: `~/.gemini/antigravity-cli/antigravity-oauth-token`
+- Marker: `~/.gemini/antigravity-cli/cache/antigravity-keyring-unavailable`
+
+This is the normal case on Linux, where a session often has no secret service. UsagePal tries the
+keyring first and then the file, so macOS behaviour is unchanged and Linux works without a keyring.
+The file may hold a bare token, a `Bearer` value, JSON containing a token field, or a
+`go-keyring-base64:` wrapper; all four are accepted.
 
 For `agy`, UsagePal calls:
 
@@ -262,8 +299,23 @@ The Cloud Code model set is a superset of the LS model set. The LS returns only 
 
 1. Probe the Antigravity app/IDE language server.
 2. Probe the `agy` local language server.
-3. Read SQLite token candidates from both Antigravity state DB paths.
+3. Read SQLite token candidates from this platform's Antigravity state DB paths.
 4. Try unexpired SQLite/cached access tokens with `fetchAvailableModels`.
 5. Refresh SQLite refresh tokens only after auth failure or when no access token exists.
-6. Read `agy` keychain token from service `gemini`, account `antigravity`, then call `loadCodeAssist` and `retrieveUserQuota`.
-7. If all strategies fail: error "Start Antigravity or run `agy` and try again."
+6. Read the `agy` token from the keyring, then from its token file, then call `loadCodeAssist` and `retrieveUserQuota`.
+7. If no credentials were found anywhere: error "Start Antigravity or run `agy` and try again."
+8. If credentials existed but Cloud Code was unreachable or answered with an error: "Can't reach Antigravity right now. Try again shortly."
+
+## What UsagePal Shows
+
+- **Three pool bars** — Gemini Pro, Gemini Flash and Claude, each reporting the worst remaining
+  fraction among the models in that pool. Non-Gemini models share one quota bucket, so anything
+  that matches no rule is folded into Claude and logged, which is how a new model family shows up.
+- **A line per model**, below the pools, at its own remaining fraction. Variants that differ only by
+  a suffix — "Gemini 3 Pro (High)" and "(Low)" — collapse into one line at the worse value.
+- **Usage Trend** — a bar per day holding that day's peak quota used across pools. Antigravity keeps
+  no history, so UsagePal samples what it reports and stores the series in the plugin's data
+  directory (`history.json`, 31 days). Days when the app was not running read low.
+- **Burn Rate** — quota consumed per hour inside the current reset window, for whichever pool is
+  closest to running out. Needs at least two samples spanning 15 minutes, and is withheld after a
+  reset refills the pool.

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -1,9 +1,19 @@
 (function () {
   var LS_SERVICE = "exa.language_server_pb.LanguageServerService"
-  var STATE_DBS = [
-    "~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb",
-    "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb",
-  ]
+  // Antigravity IDE is a VS Code fork, so its state DB sits under the standard
+  // per-OS user-data dir. "Antigravity IDE" is the current folder; "Antigravity"
+  // is the pre-2.0 one, still present on machines that upgraded.
+  var STATE_DB_BASES = {
+    macos: "~/Library/Application Support/",
+    linux: "~/.config/",
+    windows: "~/AppData/Roaming/",
+  }
+  var STATE_DB_DIRS = ["Antigravity IDE", "Antigravity"]
+  var STATE_DB_LEAF = "/User/globalStorage/state.vscdb"
+  // agy caches its OAuth token in the OS keyring, but falls back to this file
+  // whenever the keyring is unavailable — the common case on Linux, where a
+  // headless or dbus-less session has no secret service.
+  var AGY_TOKEN_FILE = "~/.gemini/antigravity-cli/antigravity-oauth-token"
   var AGY_KEYCHAIN_SERVICE = "gemini"
   var AGY_KEYCHAIN_ACCOUNT = "antigravity"
   var CLOUD_CODE_URLS = [
@@ -14,6 +24,7 @@
   var FETCH_MODELS_PATH = "/v1internal:fetchAvailableModels"
   var RETRIEVE_QUOTA_PATH = "/v1internal:retrieveUserQuota"
   var LOGIN_MESSAGE = "Start Antigravity or run `agy` and try again."
+  var UNREACHABLE_MESSAGE = "Can't reach Antigravity right now. Try again shortly."
   var GOOGLE_OAUTH_URL = "https://oauth2.googleapis.com/token"
   var GOOGLE_CLIENT_ID = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
   var GOOGLE_CLIENT_SECRET = "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"
@@ -126,10 +137,30 @@
     }
   }
 
+  // Unknown platforms probe every base path, so a host that reports something
+  // we don't branch on still finds the DB instead of silently reporting nothing.
+  function stateDbBases(platform) {
+    var known = STATE_DB_BASES[platform]
+    if (known) return [known]
+    return [STATE_DB_BASES.macos, STATE_DB_BASES.linux, STATE_DB_BASES.windows]
+  }
+
+  function stateDbPaths(ctx) {
+    var bases = stateDbBases(ctx.app && ctx.app.platform)
+    var paths = []
+    for (var i = 0; i < bases.length; i++) {
+      for (var j = 0; j < STATE_DB_DIRS.length; j++) {
+        paths.push(bases[i] + STATE_DB_DIRS[j] + STATE_DB_LEAF)
+      }
+    }
+    return paths
+  }
+
   function loadOAuthTokenCandidates(ctx) {
+    var paths = stateDbPaths(ctx)
     var candidates = []
-    for (var i = 0; i < STATE_DBS.length; i++) {
-      var tokens = loadOAuthTokensFromDb(ctx, STATE_DBS[i])
+    for (var i = 0; i < paths.length; i++) {
+      var tokens = loadOAuthTokensFromDb(ctx, paths[i])
       if (tokens) candidates.push(tokens)
     }
     return candidates
@@ -263,6 +294,9 @@
     return text
   }
 
+  // The keychain binding exists on every platform and throws when called off
+  // macOS, so the typeof guard never fires there — the catch is what makes this
+  // safe on Windows and Linux.
   function loadAgyKeychainToken(ctx) {
     if (!ctx.host.keychain || typeof ctx.host.keychain.readGenericPassword !== "function") {
       return null
@@ -274,6 +308,27 @@
       ctx.host.log.info("agy keychain read failed: " + String(e))
       return null
     }
+  }
+
+  function loadAgyFileToken(ctx) {
+    try {
+      if (!ctx.host.fs.exists(AGY_TOKEN_FILE)) return null
+      return extractAgyAccessToken(ctx, ctx.host.fs.readText(AGY_TOKEN_FILE))
+    } catch (e) {
+      ctx.host.log.info("agy token file read failed: " + String(e))
+      return null
+    }
+  }
+
+  // Keychain first so macOS keeps its existing source of truth; the file is
+  // agy's own fallback and is the only source on a keyring-less Linux session.
+  function loadAgyTokens(ctx) {
+    var tokens = []
+    var keychainToken = loadAgyKeychainToken(ctx)
+    if (keychainToken) tokens.push(keychainToken)
+    var fileToken = loadAgyFileToken(ctx)
+    if (fileToken && tokens.indexOf(fileToken) === -1) tokens.push(fileToken)
+    return tokens
   }
 
   // --- LS discovery ---
@@ -296,6 +351,14 @@
     })
   }
 
+  // The language server expects the host OS in its request metadata. The host
+  // reports the same three names, so pass it through and fall back to macos for
+  // anything else rather than sending a value the server has never seen.
+  function lsOsName(ctx) {
+    var platform = (ctx.app && ctx.app.platform) || ""
+    return STATE_DB_BASES[platform] ? platform : "macos"
+  }
+
   function probePort(ctx, scheme, port, csrf) {
     ctx.host.http.request({
       method: "POST",
@@ -312,7 +375,7 @@
             extensionVersion: "unknown",
             ide: "antigravity",
             ideVersion: "unknown",
-            os: "macos",
+            os: lsOsName(ctx),
           },
         },
       }),
@@ -363,11 +426,17 @@
     return label.replace(/\s*\([^)]*\)\s*$/, "").trim()
   }
 
-  function poolLabel(normalizedLabel) {
+  // All non-Gemini models (Claude, GPT-OSS, etc.) share a single quota pool, so
+  // anything unrecognized lands there. Pool labels are fixed because overview
+  // membership is an exact match against the manifest, so a new model family
+  // can't get its own overview line — it gets logged here and shown at its real
+  // value on its own per-model line instead.
+  function poolLabel(ctx, normalizedLabel) {
     var lower = normalizedLabel.toLowerCase()
     if (lower.indexOf("gemini") !== -1 && lower.indexOf("pro") !== -1) return "Gemini Pro"
     if (lower.indexOf("gemini") !== -1 && lower.indexOf("flash") !== -1) return "Gemini Flash"
-    // All non-Gemini models (Claude, GPT-OSS, etc.) share a single quota pool
+    if (lower.indexOf("claude") !== -1) return "Claude"
+    ctx.host.log.info("model '" + normalizedLabel + "' matched no pool rule; folded into Claude")
     return "Claude"
   }
 
@@ -383,6 +452,16 @@
 
   var QUOTA_PERIOD_MS = 5 * 60 * 60 * 1000 // 5 hours
 
+  // Labels that appear on the overview card. They must match plugin.json.
+  var POOL_LABELS = ["Gemini Pro", "Gemini Flash", "Claude"]
+  var HISTORY_FILE_NAME = "history.json"
+  var HISTORY_RETENTION_MS = 31 * 24 * 60 * 60 * 1000
+  var HISTORY_MAX_SAMPLES = 1500
+  var HISTORY_MIN_SAMPLE_GAP_MS = 60 * 1000
+  var TREND_MAX_DAYS = 31
+  var TREND_MIN_DAYS = 2
+  var BURN_RATE_MIN_SPAN_MS = 15 * 60 * 1000
+
   function modelLine(ctx, label, remainingFraction, resetTime) {
     var clamped = Math.max(0, Math.min(1, remainingFraction))
     var used = Math.round((1 - clamped) * 100)
@@ -396,29 +475,19 @@
     })
   }
 
-  function buildModelLines(ctx, configs) {
-    var deduped = {}
-    for (var i = 0; i < configs.length; i++) {
-      var c = configs[i]
-      var label = (typeof c.label === "string") ? c.label.trim() : ""
-      if (!label) continue
-      var qi = c.quotaInfo
-      var frac = (qi && typeof qi.remainingFraction === "number") ? qi.remainingFraction : 0
-      var rtime = (qi && qi.resetTime) || undefined
-      var pool = poolLabel(normalizeLabel(label))
-      if (!deduped[pool] || frac < deduped[pool].remainingFraction) {
-        deduped[pool] = {
-          label: pool,
-          remainingFraction: frac,
-          resetTime: rtime,
-        }
-      }
+  // A pool reports its worst model, so a drained variant is never hidden behind
+  // a healthy sibling.
+  function keepWorst(bucket, label, remainingFraction, resetTime) {
+    if (!bucket[label] || remainingFraction < bucket[label].remainingFraction) {
+      bucket[label] = { label: label, remainingFraction: remainingFraction, resetTime: resetTime }
     }
+  }
 
+  function sortedLines(ctx, bucket) {
     var models = []
-    var keys = Object.keys(deduped)
+    var keys = Object.keys(bucket)
     for (var i = 0; i < keys.length; i++) {
-      var m = deduped[keys[i]]
+      var m = bucket[keys[i]]
       m.sortKey = modelSortKey(m.label)
       models.push(m)
     }
@@ -434,7 +503,246 @@
     return lines
   }
 
+  // Pool lines first — their labels match the manifest, which is what puts them
+  // on the overview card. The per-model lines that follow carry labels the
+  // manifest doesn't declare, so the UI renders them as detail-only model rows.
+  function buildModelLines(ctx, configs) {
+    var pools = {}
+    var models = {}
+    for (var i = 0; i < configs.length; i++) {
+      var c = configs[i]
+      var label = (typeof c.label === "string") ? c.label.trim() : ""
+      if (!label) continue
+      var qi = c.quotaInfo
+      var frac = (qi && typeof qi.remainingFraction === "number") ? qi.remainingFraction : 0
+      var rtime = (qi && qi.resetTime) || undefined
+      var normalized = normalizeLabel(label)
+      keepWorst(pools, poolLabel(ctx, normalized), frac, rtime)
+      keepWorst(models, normalized, frac, rtime)
+    }
+
+    // A model whose own name is already a pool name would produce two lines
+    // sharing a label, which the UI keys on — drop the duplicate.
+    var modelKeys = Object.keys(models)
+    for (var k = 0; k < modelKeys.length; k++) {
+      if (pools[modelKeys[k]]) delete models[modelKeys[k]]
+    }
+
+    return sortedLines(ctx, pools).concat(sortedLines(ctx, models))
+  }
+
+  // --- Usage history ---
+
+  // Antigravity reports a remaining fraction and nothing else: no token counts,
+  // no request counts, no cost, and no history of its own. The only way to show
+  // a trend is to sample what it does report and keep the samples ourselves.
+  // Every probe runs in a fresh runtime, so the series has to round-trip through
+  // the plugin data dir.
+  function historyPath(ctx) {
+    var dir = ctx.app && ctx.app.pluginDataDir
+    return dir ? dir + "/" + HISTORY_FILE_NAME : null
+  }
+
+  function isUsableSample(sample) {
+    return !!sample &&
+      typeof sample.ts === "number" &&
+      isFinite(sample.ts) &&
+      !!sample.pools &&
+      typeof sample.pools === "object"
+  }
+
+  function loadHistory(ctx) {
+    var path = historyPath(ctx)
+    if (!path) return []
+    try {
+      if (!ctx.host.fs.exists(path)) return []
+      var parsed = ctx.util.tryParseJson(ctx.host.fs.readText(path))
+      if (!parsed || !Array.isArray(parsed.samples)) return []
+      var samples = []
+      for (var i = 0; i < parsed.samples.length; i++) {
+        if (isUsableSample(parsed.samples[i])) samples.push(parsed.samples[i])
+      }
+      return samples
+    } catch (e) {
+      ctx.host.log.warn("failed to read usage history: " + String(e))
+      return []
+    }
+  }
+
+  function saveHistory(ctx, samples) {
+    var path = historyPath(ctx)
+    if (!path) return
+    try {
+      ctx.host.fs.writeText(path, JSON.stringify({ v: 1, samples: samples }))
+    } catch (e) {
+      ctx.host.log.warn("failed to persist usage history: " + String(e))
+    }
+  }
+
+  function poolUsageFromLines(lines) {
+    var pools = {}
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i]
+      if (line.type !== "progress") continue
+      if (POOL_LABELS.indexOf(line.label) === -1) continue
+      pools[line.label] = line.used
+    }
+    return pools
+  }
+
+  // The pool closest to running out — the one worth charting and pacing.
+  // Ties resolve in manifest order so the choice doesn't flicker between probes.
+  function topPool(pools) {
+    var top = null
+    for (var i = 0; i < POOL_LABELS.length; i++) {
+      var label = POOL_LABELS[i]
+      var used = pools[label]
+      if (typeof used !== "number" || !isFinite(used)) continue
+      if (!top || used > top.used) top = { label: label, used: used }
+    }
+    return top
+  }
+
+  // Returns the new sample list, or null when this probe is too close to the
+  // previous sample to be worth recording (rapid manual refreshes).
+  function recordSample(samples, pools, nowMs) {
+    if (Object.keys(pools).length === 0) return null
+    var last = samples.length ? samples[samples.length - 1] : null
+    if (last && nowMs - last.ts < HISTORY_MIN_SAMPLE_GAP_MS) return null
+
+    var next = []
+    var cutoff = nowMs - HISTORY_RETENTION_MS
+    for (var i = 0; i < samples.length; i++) {
+      if (samples[i].ts >= cutoff && samples[i].ts <= nowMs) next.push(samples[i])
+    }
+    next.push({ ts: nowMs, pools: pools })
+    if (next.length > HISTORY_MAX_SAMPLES) next = next.slice(next.length - HISTORY_MAX_SAMPLES)
+    return next
+  }
+
+  function pad2(value) {
+    return value < 10 ? "0" + value : String(value)
+  }
+
+  function dayKey(ts) {
+    var d = new Date(ts)
+    return d.getFullYear() + "-" + pad2(d.getMonth() + 1) + "-" + pad2(d.getDate())
+  }
+
+  function dayLabel(key) {
+    return Number(key.slice(5, 7)) + "/" + Number(key.slice(8, 10))
+  }
+
+  function trendPoints(samples) {
+    var byDay = {}
+    for (var i = 0; i < samples.length; i++) {
+      var top = topPool(samples[i].pools)
+      if (!top) continue
+      var key = dayKey(samples[i].ts)
+      if (!byDay[key] || top.used > byDay[key].used) byDay[key] = top
+    }
+
+    var keys = Object.keys(byDay).sort()
+    if (keys.length > TREND_MAX_DAYS) keys = keys.slice(keys.length - TREND_MAX_DAYS)
+
+    var points = []
+    for (var j = 0; j < keys.length; j++) {
+      var peak = byDay[keys[j]]
+      points.push({
+        label: dayLabel(keys[j]),
+        value: peak.used,
+        valueLabel: peak.used + "% " + peak.label,
+      })
+    }
+    return points
+  }
+
+  function poolResetsAt(lines, label) {
+    for (var i = 0; i < lines.length; i++) {
+      if (lines[i].label === label && lines[i].resetsAt) return lines[i].resetsAt
+    }
+    return null
+  }
+
+  function formatBurnRate(percentPerHour) {
+    return percentPerHour >= 10
+      ? String(Math.round(percentPerHour))
+      : String(Math.round(percentPerHour * 10) / 10)
+  }
+
+  // Consumption within the pool's current reset window. Samples from an earlier
+  // window would compare against a quota that has since refilled, so the window
+  // start is the cutoff.
+  function burnRateLine(ctx, samples, lines, nowMs) {
+    var top = topPool(poolUsageFromLines(lines))
+    if (!top) return null
+
+    // A reset time already in the past means the provider's value is stale, so
+    // deriving the window from it would compare against an unbounded stretch of
+    // history. Fall back to the trailing period instead.
+    var resetsAtMs = ctx.util.parseDateMs(poolResetsAt(lines, top.label))
+    var windowStart = (typeof resetsAtMs === "number" && isFinite(resetsAtMs) && resetsAtMs > nowMs)
+      ? resetsAtMs - QUOTA_PERIOD_MS
+      : nowMs - QUOTA_PERIOD_MS
+
+    var inWindow = []
+    for (var i = 0; i < samples.length; i++) {
+      var used = samples[i].pools[top.label]
+      if (samples[i].ts < windowStart) continue
+      if (typeof used !== "number" || !isFinite(used)) continue
+      inWindow.push({ ts: samples[i].ts, used: used })
+    }
+    if (inWindow.length < 2) return null
+
+    var first = inWindow[0]
+    var last = inWindow[inWindow.length - 1]
+    var elapsedMs = last.ts - first.ts
+    if (elapsedMs < BURN_RATE_MIN_SPAN_MS) return null
+
+    var delta = last.used - first.used
+    if (delta <= 0) return null
+
+    var rate = delta / (elapsedMs / 3600000)
+    return ctx.line.text({
+      label: "Burn Rate",
+      value: formatBurnRate(rate) + "%/hr",
+      subtitle: top.label + " · over " + ctx.fmt.resetIn(Math.round(elapsedMs / 1000)),
+    })
+  }
+
+  function withUsageHistory(ctx, result) {
+    if (!result || !Array.isArray(result.lines)) return result
+
+    var nowMs = Date.now()
+    var samples = loadHistory(ctx)
+    var recorded = recordSample(samples, poolUsageFromLines(result.lines), nowMs)
+    if (recorded) {
+      saveHistory(ctx, recorded)
+      samples = recorded
+    }
+
+    var burnRate = burnRateLine(ctx, samples, result.lines, nowMs)
+    if (burnRate) result.lines.push(burnRate)
+
+    var points = trendPoints(samples)
+    if (points.length >= TREND_MIN_DAYS) {
+      result.lines.push(ctx.line.barChart({
+        label: "Usage Trend",
+        points: points,
+        note: "Peak quota used per day, sampled while UsagePal is running.",
+        color: "#4285F4",
+      }))
+    }
+
+    return result
+  }
+
   // --- Cloud Code API ---
+
+  // Set whenever Cloud Code itself misbehaves — unreachable, 5xx, or a body we
+  // can't parse — as opposed to rejecting our credentials. It decides which
+  // failure message the user sees, so an outage doesn't read as "signed out".
+  var sawTransportFailure = false
 
   function requestCloudCodeJson(ctx, path, token, userAgent, body) {
     for (var i = 0; i < CLOUD_CODE_URLS.length; i++) {
@@ -453,6 +761,7 @@
         })
         if (!resp || typeof resp.status !== "number" || !Number.isFinite(resp.status)) {
           ctx.host.log.warn("Cloud Code returned invalid response shape (" + CLOUD_CODE_URLS[i] + ")")
+          sawTransportFailure = true
           continue
         }
         if (ctx.util.isAuthStatus(resp.status)) return { _authFailed: true }
@@ -460,12 +769,15 @@
           var json = ctx.util.tryParseJson(resp.bodyText)
           if (!json || typeof json !== "object") {
             ctx.host.log.warn("Cloud Code returned invalid JSON (" + CLOUD_CODE_URLS[i] + ")")
+            sawTransportFailure = true
             continue
           }
           return json
         }
+        sawTransportFailure = true
       } catch (e) {
         ctx.host.log.warn("Cloud Code request failed (" + CLOUD_CODE_URLS[i] + "): " + String(e))
+        sawTransportFailure = true
       }
     }
     return null
@@ -637,11 +949,13 @@
   // --- Probe ---
 
   function probe(ctx) {
+    sawTransportFailure = false
+
     var lsResult = probeLs(ctx)
-    if (lsResult) return lsResult
+    if (lsResult) return withUsageHistory(ctx, lsResult)
 
     var agyLsResult = probeAgyLs(ctx)
-    if (agyLsResult) return agyLsResult
+    if (agyLsResult) return withUsageHistory(ctx, agyLsResult)
 
     var dbTokenCandidates = loadOAuthTokenCandidates(ctx)
 
@@ -691,10 +1005,10 @@
     }
 
     if (!ccData || ccData._authFailed) {
-      var agyToken = loadAgyKeychainToken(ctx)
-      if (agyToken) {
-        var agyResult = probeAgyCloudCode(ctx, agyToken)
-        if (agyResult && !agyResult._authFailed) return agyResult
+      var agyTokens = loadAgyTokens(ctx)
+      for (var a = 0; a < agyTokens.length; a++) {
+        var agyResult = probeAgyCloudCode(ctx, agyTokens[a])
+        if (agyResult && !agyResult._authFailed) return withUsageHistory(ctx, agyResult)
         if (agyResult && agyResult._authFailed) ccData = agyResult
       }
     }
@@ -702,9 +1016,10 @@
     if (ccData && !ccData._authFailed) {
       var configs = parseCloudCodeModels(ccData)
       var lines = buildModelLines(ctx, configs)
-      if (lines.length > 0) return { plan: null, lines: lines }
+      if (lines.length > 0) return withUsageHistory(ctx, { plan: null, lines: lines })
     }
 
+    if (sawTransportFailure) throw UNREACHABLE_MESSAGE
     throw LOGIN_MESSAGE
   }
 

--- a/plugins/antigravity/plugin.json
+++ b/plugins/antigravity/plugin.json
@@ -2,17 +2,24 @@
   "schemaVersion": 1,
   "id": "antigravity",
   "name": "Antigravity",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "entry": "plugin.js",
   "icon": "icon.svg",
   "brandColor": "#4285F4",
   "detect": [
     { "file": "~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb" },
-    { "file": "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb" }
+    { "file": "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb" },
+    { "file": "~/.config/Antigravity IDE/User/globalStorage/state.vscdb" },
+    { "file": "~/.config/Antigravity/User/globalStorage/state.vscdb" },
+    { "file": "~/AppData/Roaming/Antigravity IDE/User/globalStorage/state.vscdb" },
+    { "file": "~/AppData/Roaming/Antigravity/User/globalStorage/state.vscdb" },
+    { "file": "~/.gemini/antigravity-cli/antigravity-oauth-token" }
   ],
   "lines": [
     { "type": "progress", "label": "Gemini Pro", "scope": "overview", "primaryOrder": 1 },
     { "type": "progress", "label": "Gemini Flash", "scope": "overview" },
-    { "type": "progress", "label": "Claude", "scope": "overview" }
+    { "type": "progress", "label": "Claude", "scope": "overview" },
+    { "type": "text", "label": "Burn Rate", "scope": "detail" },
+    { "type": "barChart", "label": "Usage Trend", "scope": "detail" }
   ]
 }

--- a/plugins/antigravity/plugin.test.js
+++ b/plugins/antigravity/plugin.test.js
@@ -10,7 +10,24 @@ const OAUTH_TOKEN_KEY = "antigravityUnifiedStateSync.oauthToken"
 const OAUTH_TOKEN_SENTINEL = "oauthTokenInfoSentinelKey"
 const STATE_DB_V2 = "~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb"
 const STATE_DB_V1 = "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb"
+const LINUX_STATE_DB_V2 = "~/.config/Antigravity IDE/User/globalStorage/state.vscdb"
+const LINUX_STATE_DB_V1 = "~/.config/Antigravity/User/globalStorage/state.vscdb"
+const WINDOWS_STATE_DB_V2 = "~/AppData/Roaming/Antigravity IDE/User/globalStorage/state.vscdb"
+const WINDOWS_STATE_DB_V1 = "~/AppData/Roaming/Antigravity/User/globalStorage/state.vscdb"
+const AGY_TOKEN_FILE = "~/.gemini/antigravity-cli/antigravity-oauth-token"
+const HISTORY_FILE = "/tmp/usagepal-test/plugin/history.json"
 const LOGIN_MESSAGE = "Start Antigravity or run `agy` and try again."
+const UNREACHABLE_MESSAGE = "Can't reach Antigravity right now. Try again shortly."
+
+// Pool lines carry the manifest labels and drive the overview card; every other
+// progress line is a per-model detail row.
+const POOL_LABELS = ["Gemini Pro", "Gemini Flash", "Claude"]
+const poolLabels = (result) =>
+  result.lines.filter((line) => POOL_LABELS.includes(line.label)).map((line) => line.label)
+const modelLabels = (result) =>
+  result.lines
+    .filter((line) => line.type === "progress" && !POOL_LABELS.includes(line.label))
+    .map((line) => line.label)
 
 // --- Fixtures ---
 
@@ -272,7 +289,7 @@ describe("antigravity plugin", () => {
 
     expect(capturedCsrf).toBe("")
     expect(result.plan).toBe("Google AI Pro")
-    expect(result.lines.map((l) => l.label)).toEqual(["Gemini Pro", "Gemini Flash", "Claude"])
+    expect(poolLabels(result)).toEqual(["Gemini Pro", "Gemini Flash", "Claude"])
   })
 
   it("returns models + plan from GetUserStatus", async () => {
@@ -288,7 +305,7 @@ describe("antigravity plugin", () => {
     expect(result.plan).toBe("Pro")
 
     // Model lines exist — 3 pool lines
-    const labels = result.lines.map((l) => l.label)
+    const labels = poolLabels(result)
     expect(labels).toEqual(["Gemini Pro", "Gemini Flash", "Claude"])
   })
 
@@ -316,7 +333,7 @@ describe("antigravity plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
 
-    const labels = result.lines.map((l) => l.label)
+    const labels = poolLabels(result)
 
     expect(labels).toEqual(["Gemini Pro", "Gemini Flash", "Claude"])
   })
@@ -439,7 +456,7 @@ describe("antigravity plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result).toBeTruthy()
-    const labels = result.lines.map((l) => l.label)
+    const labels = poolLabels(result)
     expect(labels).toEqual(["Gemini Pro", "Claude"])
     expect(result.lines.every((l) => l.used === 100)).toBe(true)
   })
@@ -458,8 +475,8 @@ describe("antigravity plugin", () => {
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    expect(result.lines.length).toBe(1)
-    expect(result.lines[0].label).toBe("Gemini Pro")
+    expect(poolLabels(result)).toEqual(["Gemini Pro"])
+    expect(modelLabels(result)).toEqual(["Gemini 3 Pro"])
   })
 
   it("includes resetsAt on model lines", async () => {
@@ -676,7 +693,7 @@ describe("antigravity plugin", () => {
       "https://daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota",
     ])
     expect(result.plan).toBe("Google AI Pro")
-    expect(result.lines.map((l) => l.label)).toEqual(["Gemini Pro", "Gemini Flash", "Claude"])
+    expect(poolLabels(result)).toEqual(["Gemini Pro", "Gemini Flash", "Claude"])
   })
 
   it("tries agy Cloud Code even when the keychain token matches a SQLite token", async () => {
@@ -1306,7 +1323,7 @@ describe("antigravity plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
 
-    const labels = result.lines.map((l) => l.label)
+    const labels = poolLabels(result)
     expect(labels).toEqual(["Gemini Pro"])
   })
 
@@ -1347,7 +1364,7 @@ describe("antigravity plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
 
-    const labels = result.lines.map((l) => l.label)
+    const labels = poolLabels(result)
     expect(labels).toEqual(["Claude"])
   })
 
@@ -1388,7 +1405,7 @@ describe("antigravity plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
 
-    const labels = result.lines.map((l) => l.label)
+    const labels = poolLabels(result)
     expect(labels).toEqual(["Gemini Pro", "Claude"])
   })
 
@@ -1419,7 +1436,7 @@ describe("antigravity plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
 
-    const labels = result.lines.map((l) => l.label)
+    const labels = poolLabels(result)
     expect(labels).toEqual(["Gemini Pro", "Claude"])
   })
 
@@ -1544,7 +1561,7 @@ describe("antigravity plugin", () => {
     const result = plugin.probe(ctx)
 
     expect(result.plan).toBe("Google AI Ultra")
-    const labels = result.lines.map((l) => l.label)
+    const labels = poolLabels(result)
     expect(labels).toEqual(["Gemini Pro", "Gemini Flash", "Claude"])
   })
 
@@ -1686,7 +1703,7 @@ describe("antigravity plugin", () => {
     })
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow(LOGIN_MESSAGE)
+    expect(() => plugin.probe(ctx)).toThrow(UNREACHABLE_MESSAGE)
     expect(refreshCalls).toBe(0)
   })
 
@@ -1716,7 +1733,360 @@ describe("antigravity plugin", () => {
     })
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow(LOGIN_MESSAGE)
+    expect(() => plugin.probe(ctx)).toThrow(UNREACHABLE_MESSAGE)
     expect(refreshCalls).toBe(0)
+  })
+
+  // --- Platform paths ---
+
+  const queriedDbs = (ctx) => ctx.host.sqlite.query.mock.calls.map((call) => call[0])
+
+  const platformCases = [
+    { platform: "macos", expected: [STATE_DB_V2, STATE_DB_V1] },
+    { platform: "linux", expected: [LINUX_STATE_DB_V2, LINUX_STATE_DB_V1] },
+    { platform: "windows", expected: [WINDOWS_STATE_DB_V2, WINDOWS_STATE_DB_V1] },
+  ]
+
+  for (const testCase of platformCases) {
+    it("reads the " + testCase.platform + " state databases, current folder first", async () => {
+      const ctx = makeCtx()
+      ctx.app.platform = testCase.platform
+      ctx.host.ls.discover.mockReturnValue(null)
+
+      const plugin = await loadPlugin()
+      expect(() => plugin.probe(ctx)).toThrow(LOGIN_MESSAGE)
+      expect(queriedDbs(ctx)).toEqual(testCase.expected)
+    })
+  }
+
+  it("probes every platform's state databases when the platform is unknown", async () => {
+    const ctx = makeCtx()
+    ctx.app.platform = "freebsd"
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow(LOGIN_MESSAGE)
+    expect(queriedDbs(ctx)).toEqual([
+      STATE_DB_V2,
+      STATE_DB_V1,
+      LINUX_STATE_DB_V2,
+      LINUX_STATE_DB_V1,
+      WINDOWS_STATE_DB_V2,
+      WINDOWS_STATE_DB_V1,
+    ])
+  })
+
+  it("reads Linux credentials from the XDG config path", async () => {
+    const ctx = makeCtx()
+    ctx.app.platform = "linux"
+    ctx.host.ls.discover.mockReturnValue(null)
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    setupSqliteByPath(ctx, {
+      [LINUX_STATE_DB_V2]: makeOAuthSentinelB64(ctx, { accessToken: "linux-token", expirySeconds: futureExpiry }),
+    })
+
+    const seen = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      seen.push(opts.headers.Authorization)
+      return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(seen[0]).toBe("Bearer linux-token")
+    expect(poolLabels(result)).toEqual(["Gemini Pro", "Claude"])
+  })
+
+  it("sends the host platform in language server metadata", async () => {
+    const ctx = makeCtx()
+    ctx.app.platform = "linux"
+    setupLsMock(ctx, makeDiscovery(), makeUserStatusResponse())
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    const probeCall = ctx.host.http.request.mock.calls.find((call) =>
+      String(call[0].url).includes("GetUnleashData")
+    )
+    expect(JSON.parse(probeCall[0].bodyText).context.properties.os).toBe("linux")
+  })
+
+  // --- agy token file ---
+
+  it("falls back to the agy token file when the keychain is unavailable", async () => {
+    const ctx = makeCtx()
+    ctx.app.platform = "linux"
+    ctx.host.ls.discover.mockReturnValue(null)
+    // Off macOS the binding exists but throws, so only the catch protects us.
+    ctx.host.keychain.readGenericPassword.mockImplementation(() => {
+      throw new Error("keychain API is only supported on macOS")
+    })
+    ctx.host.fs.writeText(AGY_TOKEN_FILE, JSON.stringify({ tokens: { access_token: "agy-file-token" } }))
+
+    const seen = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      seen.push(opts.headers.Authorization)
+      if (url.includes("loadCodeAssist")) {
+        return { status: 200, bodyText: JSON.stringify(makeAgyLoadResponse()) }
+      }
+      if (url.includes("retrieveUserQuota")) {
+        return { status: 200, bodyText: JSON.stringify(makeAgyQuotaResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("Google AI Pro")
+    expect(seen.every((auth) => auth === "Bearer agy-file-token")).toBe(true)
+  })
+
+  it("accepts a bare token in the agy token file", async () => {
+    const ctx = makeCtx()
+    ctx.app.platform = "linux"
+    ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.fs.writeText(AGY_TOKEN_FILE, "  ya29.bare-agy-token\n")
+
+    const seen = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      seen.push(opts.headers.Authorization)
+      if (url.includes("loadCodeAssist")) {
+        return { status: 200, bodyText: JSON.stringify(makeAgyLoadResponse()) }
+      }
+      if (url.includes("retrieveUserQuota")) {
+        return { status: 200, bodyText: JSON.stringify(makeAgyQuotaResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    expect(seen.every((auth) => auth === "Bearer ya29.bare-agy-token")).toBe(true)
+  })
+
+  // --- Per-model detail lines ---
+
+  it("adds one detail line per model beneath the pool lines", async () => {
+    const ctx = makeCtx()
+    setupLsMock(ctx, makeDiscovery(), makeUserStatusResponse())
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(poolLabels(result)).toEqual(["Gemini Pro", "Gemini Flash", "Claude"])
+    expect(modelLabels(result)).toEqual([
+      "Gemini 3.1 Pro",
+      "Gemini 3 Flash",
+      "Claude Opus 4.6",
+      "Claude Sonnet 4.6",
+      "GPT-OSS 120B",
+    ])
+  })
+
+  it("collapses model variants and keeps the worst fraction on the model line", async () => {
+    const ctx = makeCtx()
+    const response = makeUserStatusResponse({
+      configs: [
+        {
+          label: "Gemini 3.1 Pro (High)",
+          quotaInfo: { remainingFraction: 0.8, resetTime: "2026-02-08T09:10:56Z" },
+        },
+        {
+          label: "Gemini 3.1 Pro (Low)",
+          quotaInfo: { remainingFraction: 0.25, resetTime: "2026-02-08T09:10:56Z" },
+        },
+      ],
+    })
+    setupLsMock(ctx, makeDiscovery(), response)
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(modelLabels(result)).toEqual(["Gemini 3.1 Pro"])
+    const model = result.lines.find((line) => line.label === "Gemini 3.1 Pro")
+    expect(model.used).toBe(75)
+  })
+
+  it("logs a model that matches no pool rule and still shows its own line", async () => {
+    const ctx = makeCtx()
+    const response = makeUserStatusResponse({
+      configs: [
+        {
+          label: "Nova 1 (Fast)",
+          quotaInfo: { remainingFraction: 0.5, resetTime: "2026-02-08T09:10:56Z" },
+        },
+      ],
+    })
+    setupLsMock(ctx, makeDiscovery(), response)
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(ctx.host.log.info).toHaveBeenCalledWith(expect.stringContaining("matched no pool rule"))
+    expect(poolLabels(result)).toEqual(["Claude"])
+    expect(modelLabels(result)).toEqual(["Nova 1"])
+  })
+
+  // --- Usage history ---
+
+  const lastHistoryWrite = (ctx) => {
+    const writes = ctx.host.fs.writeText.mock.calls.filter((call) => call[0] === HISTORY_FILE)
+    return writes.length ? JSON.parse(writes[writes.length - 1][1]) : null
+  }
+
+  const noonDaysAgo = (days) => {
+    const day = new Date()
+    day.setHours(12, 0, 0, 0)
+    return day.getTime() - days * 24 * 60 * 60 * 1000
+  }
+
+  it("records a usage sample on the first probe", async () => {
+    const ctx = makeCtx()
+    setupLsMock(ctx, makeDiscovery(), makeUserStatusResponse())
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    const state = lastHistoryWrite(ctx)
+    expect(state.v).toBe(1)
+    expect(state.samples).toHaveLength(1)
+    expect(state.samples[0].pools).toEqual({
+      "Gemini Pro": 20,
+      "Gemini Flash": 0,
+      Claude: 100,
+    })
+  })
+
+  it("omits the trend chart until two days of samples exist", async () => {
+    const ctx = makeCtx()
+    setupLsMock(ctx, makeDiscovery(), makeUserStatusResponse())
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.lines.find((line) => line.type === "barChart")).toBeUndefined()
+  })
+
+  it("charts the daily peak across pools once two days exist", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText(HISTORY_FILE, JSON.stringify({
+      v: 1,
+      samples: [
+        { ts: noonDaysAgo(2), pools: { "Gemini Pro": 10, Claude: 40 } },
+        { ts: noonDaysAgo(2) + 3600000, pools: { "Gemini Pro": 30, Claude: 20 } },
+        { ts: noonDaysAgo(1), pools: { "Gemini Pro": 55, Claude: 5 } },
+      ],
+    }))
+    setupLsMock(ctx, makeDiscovery(), makeUserStatusResponse())
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    const chart = result.lines.find((line) => line.type === "barChart")
+    expect(chart.label).toBe("Usage Trend")
+    expect(chart.points).toHaveLength(3)
+    expect(chart.points[0]).toMatchObject({ value: 40, valueLabel: "40% Claude" })
+    expect(chart.points[1]).toMatchObject({ value: 55, valueLabel: "55% Gemini Pro" })
+    expect(chart.points[2]).toMatchObject({ value: 100, valueLabel: "100% Claude" })
+  })
+
+  it("drops samples older than the retention window", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText(HISTORY_FILE, JSON.stringify({
+      v: 1,
+      samples: [
+        { ts: noonDaysAgo(40), pools: { "Gemini Pro": 90 } },
+        { ts: noonDaysAgo(1), pools: { "Gemini Pro": 55 } },
+      ],
+    }))
+    setupLsMock(ctx, makeDiscovery(), makeUserStatusResponse())
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    const state = lastHistoryWrite(ctx)
+    expect(state.samples).toHaveLength(2)
+    expect(state.samples[0].ts).toBe(noonDaysAgo(1))
+  })
+
+  it("ignores a corrupt history file instead of failing the probe", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText(HISTORY_FILE, "{not json")
+    setupLsMock(ctx, makeDiscovery(), makeUserStatusResponse())
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(poolLabels(result)).toEqual(["Gemini Pro", "Gemini Flash", "Claude"])
+    expect(lastHistoryWrite(ctx).samples).toHaveLength(1)
+  })
+
+  // --- Burn rate ---
+
+  it("reports burn rate for the pool closest to running out", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText(HISTORY_FILE, JSON.stringify({
+      v: 1,
+      samples: [
+        {
+          ts: Date.now() - 2 * 60 * 60 * 1000,
+          pools: { "Gemini Pro": 10, "Gemini Flash": 0, Claude: 60 },
+        },
+      ],
+    }))
+    setupLsMock(ctx, makeDiscovery(), makeUserStatusResponse())
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    const burnRate = result.lines.find((line) => line.label === "Burn Rate")
+    expect(burnRate.value).toBe("20%/hr")
+    expect(burnRate.subtitle).toContain("Claude")
+  })
+
+  it("omits burn rate when the only in-window samples span too little time", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText(HISTORY_FILE, JSON.stringify({
+      v: 1,
+      samples: [{ ts: Date.now() - 2 * 60 * 1000, pools: { "Gemini Pro": 10, Claude: 60 } }],
+    }))
+    setupLsMock(ctx, makeDiscovery(), makeUserStatusResponse())
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.lines.find((line) => line.label === "Burn Rate")).toBeUndefined()
+  })
+
+  it("omits burn rate after a quota reset refills the pool", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText(HISTORY_FILE, JSON.stringify({
+      v: 1,
+      samples: [
+        {
+          ts: Date.now() - 2 * 60 * 60 * 1000,
+          pools: { "Gemini Pro": 10, "Gemini Flash": 0, Claude: 100 },
+        },
+      ],
+    }))
+    const response = makeUserStatusResponse({
+      configs: [
+        {
+          label: "Claude Opus 4.6 (Thinking)",
+          quotaInfo: { remainingFraction: 1, resetTime: "2026-02-26T15:23:41Z" },
+        },
+      ],
+    })
+    setupLsMock(ctx, makeDiscovery(), response)
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.lines.find((line) => line.label === "Burn Rate")).toBeUndefined()
   })
 })

--- a/plugins/test-helpers.js
+++ b/plugins/test-helpers.js
@@ -8,7 +8,9 @@ export const makeCtx = () => {
     nowIso: "2026-02-02T00:00:00.000Z",
     app: {
       version: "0.0.0",
-      platform: "darwin",
+      // Matches the host, which reports Rust's std::env::consts::OS —
+      // "macos" / "linux" / "windows", never Node's "darwin".
+      platform: "macos",
       appDataDir: "/tmp/usagepal-test",
       pluginDataDir: "/tmp/usagepal-test/plugin",
     },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3093,6 +3093,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-sock-diag"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a495cb1de50560a7cd12fdcf023db70eec00e340df81be31cedbbfd4aadd6b76"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+ "smallvec",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "netstat2"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496f264d3ead4870d6b366deb9d20597592d64aac2a907f3e7d07c2325ba4663"
+dependencies = [
+ "bindgen",
+ "bitflags 2.11.0",
+ "byteorder",
+ "netlink-packet-core",
+ "netlink-packet-sock-diag",
+ "netlink-packet-utils",
+ "netlink-sys",
+ "num-derive",
+ "num-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3138,10 +3205,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "num-traits"
@@ -3330,6 +3417,16 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -5242,6 +5339,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5309,7 +5420,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5393,7 +5504,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5602,7 +5713,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -5687,7 +5798,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5712,7 +5823,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5806,7 +5917,7 @@ checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml 0.37.5",
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-version",
 ]
 
@@ -6404,6 +6515,7 @@ dependencies = [
  "keylight",
  "log",
  "mac-notification-sys",
+ "netstat2",
  "objc2",
  "objc2-foundation",
  "regex-lite",
@@ -6415,6 +6527,7 @@ dependencies = [
  "sha2 0.11.0",
  "specta",
  "specta-typescript",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-nspanel",
@@ -6831,7 +6944,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -6855,7 +6968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -6917,11 +7030,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -6931,6 +7056,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6967,7 +7101,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -7012,6 +7157,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7185,6 +7340,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7563,7 +7727,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
+tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 # `float_roundtrip`: serde_json's DEFAULT float parser is not correctly rounded
@@ -71,10 +71,13 @@ netstat2 = "0.11.2"
 sysinfo = { version = "0.39.6", default-features = false, features = ["system"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+# The panel is an NSPanel on macOS only; src/panel/other.rs covers the rest.
+# Keeping these here is what lets the crate compile for Linux and Windows.
+tauri = { version = "2", features = ["macos-private-api"] }
+tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 mac-notification-sys = "0.6.15"
 objc2 = "0.6"
 objc2-foundation = "0.3"
-tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -67,6 +67,8 @@ specta = { version = "=2.0.0-rc.25", features = ["derive"] }
 tauri-specta = { version = "=2.0.0-rc.25", features = ["derive", "typescript"] }
 specta-typescript = "0.0.12"
 ccusage-vendor = { path = "vendor/ccusage" }
+netstat2 = "0.11.2"
+sysinfo = { version = "0.39.6", default-features = false, features = ["system"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mac-notification-sys = "0.6.15"

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{LazyLock, Mutex, OnceLock};
 use std::time::{Duration, Instant};
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
 const WHITELISTED_ENV_VARS: [&str; 24] = [
     "CODEX_HOME",
@@ -85,9 +86,13 @@ static DEVIN_SESSION_RE: LazyLock<regex_lite::Regex> = LazyLock::new(|| {
 static ACCOUNT_RE: LazyLock<regex_lite::Regex> =
     LazyLock::new(|| regex_lite::Regex::new(r#"(account=)([^,\s]+)"#).expect("valid account regex"));
 
+// Both separators are covered: a plugin reading credential files on Windows
+// puts backslash paths into log messages the same way a POSIX one does.
 static PATH_RE: LazyLock<regex_lite::Regex> = LazyLock::new(|| {
-    regex_lite::Regex::new(r#"(/(?:Users|home|opt|private|var|tmp|Applications)/[^\s"')]+)"#)
-        .expect("valid path regex")
+    regex_lite::Regex::new(
+        r#"(/(?:Users|home|opt|private|var|tmp|Applications)/[^\s"')]+|[A-Za-z]:\\(?:Users|Windows|Program Files|ProgramData)\\[^\s"')]+)"#,
+    )
+    .expect("valid path regex")
 });
 
 /// JSON keys whose string values get redacted in response bodies. Order is
@@ -1470,23 +1475,12 @@ fn inject_ls<'js>(ctx: &Ctx<'js>, host: &Object<'js>, plugin_id: &str) -> rquick
                     opts.markers
                 );
 
-                let ps_output = match std::process::Command::new("/bin/ps")
-                    .args(["-ax", "-o", "pid=,command="])
-                    .output()
-                {
-                    Ok(o) => o,
-                    Err(e) => {
-                        log::warn!("[plugin:{}] ps failed: {}", pid, e);
-                        return Ok("null".to_string());
-                    }
-                };
-
-                if !ps_output.status.success() {
-                    log::warn!("[plugin:{}] ps returned non-zero", pid);
+                let processes = ls_list_processes();
+                if processes.is_empty() {
+                    log::warn!("[plugin:{}] no processes returned by the OS", pid);
                     return Ok("null".to_string());
                 }
 
-                let ps_stdout = String::from_utf8_lossy(&ps_output.stdout);
                 let process_name_lower = opts.process_name.to_lowercase();
                 let markers_lower: Vec<String> = opts
                     .markers
@@ -1502,21 +1496,11 @@ fn inject_ls<'js>(ctx: &Ctx<'js>, host: &Object<'js>, plugin_id: &str) -> rquick
                 //   2. Path substring (/<marker>/) as fallback when no flags found
                 let mut candidates: Vec<(u8, i32, String)> = Vec::new();
 
-                for line in ps_stdout.lines() {
-                    let trimmed = line.trim();
-                    if trimmed.is_empty() {
+                for (process_pid, command) in processes {
+                    let command = command.trim();
+                    if command.is_empty() {
                         continue;
                     }
-
-                    let mut parts = trimmed.splitn(2, char::is_whitespace);
-                    let pid_str = match parts.next() {
-                        Some(s) => s.trim(),
-                        None => continue,
-                    };
-                    let command = match parts.next() {
-                        Some(s) => s.trim(),
-                        None => continue,
-                    };
 
                     if !ls_command_matches_process(command, &process_name_lower) {
                         continue;
@@ -1526,9 +1510,7 @@ fn inject_ls<'js>(ctx: &Ctx<'js>, host: &Object<'js>, plugin_id: &str) -> rquick
                         continue;
                     };
 
-                    if let Ok(p) = pid_str.parse::<i32>() {
-                        candidates.push((marker_rank, p, command.to_string()));
-                    }
+                    candidates.push((marker_rank, process_pid, command.to_string()));
                 }
 
                 if candidates.is_empty() {
@@ -1536,12 +1518,16 @@ fn inject_ls<'js>(ctx: &Ctx<'js>, host: &Object<'js>, plugin_id: &str) -> rquick
                     return Ok("null".to_string());
                 }
 
-                let lsof_path = ["/usr/sbin/lsof", "/usr/bin/lsof"]
-                    .iter()
-                    .find(|p| std::path::Path::new(p).exists())
-                    .copied();
+                // Sorting by pid within a rank keeps the choice stable across
+                // probes: the OS hands back processes in no particular order,
+                // and an IDE typically runs several language-server children.
+                candidates.sort_by_key(|(marker_rank, process_pid, _)| (*marker_rank, *process_pid));
 
-                candidates.sort_by_key(|(marker_rank, _, _)| *marker_rank);
+                // A process that is actually listening always wins. One that
+                // only advertises --extension_server_port is held back as a
+                // fallback, since the port it names may belong to a sibling.
+                let mut fallback: Option<LsDiscoverResult> = None;
+
                 for (_, process_pid, command) in candidates {
                     let csrf = if opts.csrf_flag.trim().is_empty() {
                         String::new()
@@ -1569,34 +1555,7 @@ fn inject_ls<'js>(ctx: &Ctx<'js>, host: &Object<'js>, plugin_id: &str) -> rquick
                         }
                     }
 
-                    let ports = if let Some(lsof) = lsof_path {
-                        match std::process::Command::new(lsof)
-                            .args([
-                                "-nP",
-                                "-iTCP",
-                                "-sTCP:LISTEN",
-                                "-a",
-                                "-p",
-                                &process_pid.to_string(),
-                            ])
-                            .output()
-                        {
-                            Ok(o) if o.status.success() => {
-                                ls_parse_listening_ports(&String::from_utf8_lossy(&o.stdout))
-                            }
-                            Ok(_) => {
-                                log::warn!("[plugin:{}] lsof returned non-zero", pid);
-                                Vec::new()
-                            }
-                            Err(e) => {
-                                log::warn!("[plugin:{}] lsof failed: {}", pid, e);
-                                Vec::new()
-                            }
-                        }
-                    } else {
-                        log::warn!("[plugin:{}] lsof not found", pid);
-                        Vec::new()
-                    };
+                    let ports = ls_listening_ports(&pid, process_pid);
 
                     if ports.is_empty() && extension_port.is_none() {
                         log::warn!(
@@ -1607,13 +1566,7 @@ fn inject_ls<'js>(ctx: &Ctx<'js>, host: &Object<'js>, plugin_id: &str) -> rquick
                         continue;
                     }
 
-                    log::info!(
-                        "[plugin:{}] LS found: pid={}, ports={:?}, csrf=[REDACTED]",
-                        pid,
-                        process_pid,
-                        ports
-                    );
-
+                    let has_ports = !ports.is_empty();
                     let result = LsDiscoverResult {
                         pid: process_pid,
                         csrf,
@@ -1622,6 +1575,32 @@ fn inject_ls<'js>(ctx: &Ctx<'js>, host: &Object<'js>, plugin_id: &str) -> rquick
                         extension_port,
                     };
 
+                    if !has_ports {
+                        if fallback.is_none() {
+                            fallback = Some(result);
+                        }
+                        continue;
+                    }
+
+                    log::info!(
+                        "[plugin:{}] LS found: pid={}, ports={:?}, csrf=[REDACTED]",
+                        pid,
+                        process_pid,
+                        result.ports
+                    );
+
+                    return serde_json::to_string(&result).map_err(|e| {
+                        Exception::throw_message(&ctx_inner, &format!("serialize failed: {}", e))
+                    });
+                }
+
+                if let Some(result) = fallback {
+                    log::info!(
+                        "[plugin:{}] LS found: pid={}, no listening sockets, using extension port {:?}",
+                        pid,
+                        result.pid,
+                        result.extension_port
+                    );
                     return serde_json::to_string(&result).map_err(|e| {
                         Exception::throw_message(&ctx_inner, &format!("serialize failed: {}", e))
                     });
@@ -1669,6 +1648,132 @@ fn ls_extract_flag(command: &str, flag: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Every running process as `(pid, command line)`, where the command line is
+/// argv joined by spaces — the same shape `ps -o command=` produced, so the
+/// matching helpers below are unchanged. Reading the process table through
+/// sysinfo rather than `/bin/ps` is what makes discovery work on Windows.
+fn ls_list_processes() -> Vec<(i32, String)> {
+    // The argument vector has to be requested explicitly — a plain
+    // refresh_processes leaves it empty, which would strip the very flags
+    // discovery reads (--csrf_token, --extension_server_port).
+    let refresh_kind = ProcessRefreshKind::nothing()
+        .with_cmd(UpdateKind::Always)
+        .with_exe(UpdateKind::Always);
+
+    let mut system = System::new();
+    system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind);
+
+    system
+        .processes()
+        .iter()
+        .filter_map(|(process_pid, process)| {
+            let process_pid = i32::try_from(process_pid.as_u32()).ok()?;
+            let mut parts: Vec<String> = process
+                .cmd()
+                .iter()
+                .map(|arg| arg.to_string_lossy().to_string())
+                .collect();
+            // A process with no argv still has an executable path to match on.
+            if parts.is_empty() {
+                parts.push(process.exe()?.to_string_lossy().to_string());
+            }
+            Some((process_pid, parts.join(" ")))
+        })
+        .collect()
+}
+
+/// TCP ports the process is listening on.
+///
+/// netstat2 covers macOS, Linux and Windows from one code path. It reads the
+/// kernel's socket tables directly, which can come back empty where the OS
+/// withholds socket ownership, so on Unix an `lsof` sweep still backs it up.
+fn ls_listening_ports(plugin_id: &str, process_pid: i32) -> Vec<i32> {
+    let flags = netstat2::AddressFamilyFlags::IPV4 | netstat2::AddressFamilyFlags::IPV6;
+    let mut ports = std::collections::BTreeSet::new();
+    // Whether the socket table named an owner for any listener at all. Without
+    // this, a process that simply isn't listening is indistinguishable from an
+    // OS that withholds ownership, and every sibling process would pay for an
+    // lsof sweep.
+    let mut saw_any_owner = false;
+
+    match netstat2::get_sockets_info(flags, netstat2::ProtocolFlags::TCP) {
+        Ok(sockets) => {
+            for socket in sockets {
+                let netstat2::ProtocolSocketInfo::Tcp(ref tcp) = socket.protocol_socket_info else {
+                    continue;
+                };
+                if tcp.state != netstat2::TcpState::Listen || socket.associated_pids.is_empty() {
+                    continue;
+                }
+                saw_any_owner = true;
+                if socket
+                    .associated_pids
+                    .iter()
+                    .any(|owner| i32::try_from(*owner).is_ok_and(|owner| owner == process_pid))
+                {
+                    ports.insert(i32::from(tcp.local_port));
+                }
+            }
+        }
+        Err(e) => log::warn!("[plugin:{}] socket table read failed: {}", plugin_id, e),
+    }
+
+    if ports.is_empty() && !saw_any_owner {
+        for port in ls_listening_ports_via_lsof(plugin_id, process_pid) {
+            ports.insert(port);
+        }
+    }
+
+    ports.into_iter().collect()
+}
+
+#[cfg(unix)]
+fn ls_listening_ports_via_lsof(plugin_id: &str, process_pid: i32) -> Vec<i32> {
+    let Some(lsof) = ["/usr/sbin/lsof", "/usr/bin/lsof"]
+        .iter()
+        .find(|path| Path::new(path).exists())
+        .copied()
+    else {
+        log::warn!("[plugin:{}] no listening sockets found and lsof is not installed", plugin_id);
+        return Vec::new();
+    };
+
+    log::warn!(
+        "[plugin:{}] socket table reported no listening ports for pid {}; falling back to lsof",
+        plugin_id,
+        process_pid
+    );
+
+    match std::process::Command::new(lsof)
+        .args([
+            "-nP",
+            "-iTCP",
+            "-sTCP:LISTEN",
+            "-a",
+            "-p",
+            &process_pid.to_string(),
+        ])
+        .output()
+    {
+        Ok(o) if o.status.success() => {
+            ls_parse_listening_ports(&String::from_utf8_lossy(&o.stdout))
+        }
+        Ok(_) => {
+            log::warn!("[plugin:{}] lsof returned non-zero", plugin_id);
+            Vec::new()
+        }
+        Err(e) => {
+            log::warn!("[plugin:{}] lsof failed: {}", plugin_id, e);
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn ls_listening_ports_via_lsof(_plugin_id: &str, _process_pid: i32) -> Vec<i32> {
+    Vec::new()
 }
 
 fn ls_marker_rank(command: &str, markers_lower: &[String]) -> Option<u8> {
@@ -1737,6 +1842,8 @@ fn ls_command_matches_process(command: &str, process_name_lower: &str) -> bool {
 }
 
 /// Parse listening port numbers from `lsof -nP -iTCP -sTCP:LISTEN` output.
+/// Parses `lsof` output. Only reachable through the Unix fallback above.
+#[cfg_attr(not(unix), allow(dead_code))]
 fn ls_parse_listening_ports(output: &str) -> Vec<i32> {
     let mut ports = std::collections::BTreeSet::new();
     for line in output.lines() {
@@ -2830,6 +2937,38 @@ mod tests {
     }
 
     #[test]
+    fn ls_list_processes_reports_this_process_with_its_arguments() {
+        let processes = ls_list_processes();
+        assert!(!processes.is_empty(), "the OS must report running processes");
+
+        let own_pid = i32::try_from(std::process::id()).expect("pid fits in i32");
+        let (_, command) = processes
+            .iter()
+            .find(|(pid, _)| *pid == own_pid)
+            .expect("the running test process must appear in the process list");
+
+        // The whole argument vector has to survive, not just argv0: discovery
+        // reads --csrf_token and --extension_server_port out of it, and sysinfo
+        // omits arguments unless they are requested explicitly.
+        for arg in std::env::args() {
+            assert!(
+                command.contains(&arg),
+                "process command {:?} is missing argument {:?}",
+                command,
+                arg
+            );
+        }
+    }
+
+    #[test]
+    fn ls_listening_ports_is_empty_for_a_process_with_no_sockets() {
+        // The test binary listens on nothing, so this exercises the real socket
+        // table lookup and its "not listening" answer on every platform.
+        let own_pid = i32::try_from(std::process::id()).expect("pid fits in i32");
+        assert!(ls_listening_ports("test", own_pid).is_empty());
+    }
+
+    #[test]
     fn env_api_respects_allowlist_in_host_and_js() {
         let claude_env_vars = [
             "CLAUDE_CONFIG_DIR",
@@ -3370,6 +3509,22 @@ mod tests {
         assert!(
             redacted.contains("devi...3456"),
             "Devin session token should use first4...last4 redaction, got: {}",
+            redacted
+        );
+    }
+
+    #[test]
+    fn redact_log_message_redacts_windows_paths() {
+        let msg = "agy token file read failed: C:\\Users\\rebers\\.gemini\\antigravity-cli\\antigravity-oauth-token not found";
+        let redacted = redact_log_message(msg);
+        assert!(
+            !redacted.contains("rebers"),
+            "Windows user path should be redacted, got: {}",
+            redacted
+        );
+        assert!(
+            redacted.contains("[PATH]"),
+            "Windows path should be replaced with the path placeholder, got: {}",
             redacted
         );
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,8 +24,7 @@
     ],
     "security": {
       "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' tauri://localhost"
-    },
-    "macOSPrivateApi": true
+    }
   },
   "bundle": {
     "active": true,

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,5 @@
+{
+  "app": {
+    "macOSPrivateApi": true
+  }
+}


### PR DESCRIPTION
## Description

Reports what Antigravity actually exposes and makes the provider work on Linux

**Linux**
-- Resolve the IDE state database so it lists every candidate in `detect`, so the provider is detected outside of macOS; Windows has yet to be proven.
 - When the OS keyring is unavailable, the app reads the agy token from ~/.gemini/antigravity-cli/antigravity-oauth-token, which is normal for Linux; macOS is left unchanged.
 - Send the host OS in the language-server metadata instead of "macOS".
- Replace the ps and lsof subprocesses in ctx.host.ls.discover with direct process- and socket-table reads. Discovery picks deterministically among sibling language servers.
- Important note: running Linux on Wayland currently needs GDK_BACKEND=x11; the webview aborts with a GDK protocol error.
 
**Windows** is prepared but not working; will need to create a follow-up issue.  The %APPDATA% state-database paths and platform-independent discovery are in place.  It appears the main blocker remains ctx.host.sqlite, which shells out to a sqlite3 binary that Windows does not ship.   Windows targets were not compiled; in the follow-up issue I'll use Devin's VM Windows set up to test it out.

**Antigravity** metrics report no token counts, request count, or costs through its language server, the Cloud Code API, or any local file.   There are community extensions that can perhaps be investigated.  So far the metrics:
 - A line per model beneath the three pools
 - A burn-rate line for whichever pool is closest to running out
 - A distinct message for "not signed in" and "provider unreachable"

**macOS**
scope macOS-only dependencies to macOS targets

tauri-nspanel and the tauri macOS-private-api feature were declared unconditionally, so the crate could not be built for Linux even though src/panel.other.rs already provides a non-macOS panel.  Move both macOS target sections, and move macOSPrivateApi out of tauri.conf.json into a tauri.macos.conf.json overlay so the build scriptls so it can pass on Linux build.  tauri-utils merges those overlays on macOS targets, so the macOS build is unaffected.\

## Related Issue

https://github.com/Halloweedev/usagepal/issues/45
Does not complete: https://github.com/Halloweedev/usagepal/issues/54

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [x] Other (describe below)

The second commit a build-configuration change and documentation updates to `docs/providers/antigravity.md` and `docs/plugins/api.md`, which now document `ctx.host.ls.discovery` for the first time.

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

1959 JS tests and 202 Rust tests pass. Note for reviewers running tests west of
UTC: `opencode-go` has one pre-existing timezone-dependent failure ("renders
local spend lines...") that also fails on a clean `main` and passes under
`TZ=UTC`. Unrelated to this PR.

Also verified against a live Linux install: reads the state database, refreshes
the OAuth token, calls Cloud Code, and returns 3 pool lines plus 9 per-model
lines (Gemini 3.1 Pro, 3 Flash, 3.1 Flash Image, 3.1 Flash Lite, 3.5 Flash,
3.6 Flash, Claude Opus 4.6, Claude Sonnet 4.6, GPT-OSS 120B). App runs on Linux
with `GDK_BACKEND=x11`; native Wayland aborts with a GDK protocol error.

## Screenshots

<img width="488" height="696" alt="image" src="https://github.com/user-attachments/assets/f941175c-25a2-4908-8f43-f9070ffe132a" />

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

Two new Rust dependencies, both needed to drop the `ps`/`lsof` subprocesses:
`sysinfo` (process table, `default-features = false`, `system` feature only)
and `netstat2` (listening sockets). Together they replace two Unix-only
external binaries with one code path across macOS, Linux and Windows. `lsof` is
retained as a Unix fallback.

**Found while testing, not fixed here** — worth its own issue. With a large
local Codex history, the app is OOM-killed at startup: the bundled usage reader
loads session files in-process, and on a 57 GB `~/.codex` it reached 6.4 GB
within 20 seconds and was killed past 11 GB. The 15-second cap on that load is
a time limit, not a memory one, and the load is abandoned rather than cancelled
when it expires, so it keeps allocating afterwards. Controlled comparison on the
same build: point `CODEX_HOME` at a directory with credentials but no session
files and the app sits at 0.31 GB with the Codex card rendering normally. Only
reproducible on Linux today, because that is where the app can now run