### PR TITLE
fix(ccusage): bound Codex/Claude scans to prevent OOM

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5340,9 +5340,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.6"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "image-png"] }
+tauri = { version = "2", features = ["tray-icon", "image-png", "macos-private-api"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 # `float_roundtrip`: serde_json's DEFAULT float parser is not correctly rounded
@@ -68,7 +68,7 @@ tauri-specta = { version = "=2.0.0-rc.25", features = ["derive", "typescript"] }
 specta-typescript = "0.0.12"
 ccusage-vendor = { path = "vendor/ccusage" }
 netstat2 = "0.11.2"
-sysinfo = { version = "0.39.6", default-features = false, features = ["system"] }
+sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # The panel is an NSPanel on macOS only; src/panel/other.rs covers the rest.

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -1957,6 +1957,13 @@ fn ccusage_home_override<'a>(
     }
 }
 
+fn set_provider_cancel(provider: CcusageProvider, cancelled: bool) {
+    match provider {
+        CcusageProvider::Claude => ccusage_vendor::set_claude_cancel(cancelled),
+        CcusageProvider::Codex => ccusage_vendor::set_codex_cancel(cancelled),
+    }
+}
+
 fn inject_ccusage<'js>(
     ctx: &Ctx<'js>,
     host: &Object<'js>,
@@ -2040,10 +2047,7 @@ fn run_ccusage_query(opts_json: &str, plugin_id: &str, deadline: ProbeDeadline) 
     // Clear any stale cancel flag from a previous timed-out load that has since
     // finished and cleared it in the worker. The worker itself clears the flag
     // on exit, but if it panicked we clear here to avoid poisoning the next query.
-    match provider {
-        CcusageProvider::Claude => ccusage_vendor::set_claude_cancel(false),
-        CcusageProvider::Codex => ccusage_vendor::set_codex_cancel(false),
-    }
+    set_provider_cancel(provider, false);
 
     // The load runs on its own thread so the probe worker can stop waiting on
     // it. An in-process loader cannot be killed the way the old subprocess's
@@ -2066,10 +2070,7 @@ fn run_ccusage_query(opts_json: &str, plugin_id: &str, deadline: ProbeDeadline) 
         // Clear the cancel flag for this provider when the worker exits,
         // whether via success, error, or cancellation. This allows the next
         // query to start without inheriting a stale cancel.
-        match provider {
-            CcusageProvider::Claude => ccusage_vendor::set_claude_cancel(false),
-            CcusageProvider::Codex => ccusage_vendor::set_codex_cancel(false),
-        }
+        set_provider_cancel(provider, false);
     });
 
     match rx.recv_timeout(timeout) {
@@ -2088,10 +2089,7 @@ fn run_ccusage_query(opts_json: &str, plugin_id: &str, deadline: ProbeDeadline) 
                 plugin_id,
                 timeout
             );
-            match provider {
-                CcusageProvider::Claude => ccusage_vendor::set_claude_cancel(true),
-                CcusageProvider::Codex => ccusage_vendor::set_codex_cancel(true),
-            }
+            set_provider_cancel(provider, true);
             runner_failed()
         }
         Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -2037,12 +2037,21 @@ fn run_ccusage_query(opts_json: &str, plugin_id: &str, deadline: ProbeDeadline) 
     // or Codex cost. `None` before startup wiring, which is embedded-only.
     let pricing_overlay = pricing_cache::global().and_then(|cache| cache.overlay());
 
+    // Clear any stale cancel flag from a previous timed-out load that has since
+    // finished and cleared it in the worker. The worker itself clears the flag
+    // on exit, but if it panicked we clear here to avoid poisoning the next query.
+    match provider {
+        CcusageProvider::Claude => ccusage_vendor::set_claude_cancel(false),
+        CcusageProvider::Codex => ccusage_vendor::set_codex_cancel(false),
+    }
+
     // The load runs on its own thread so the probe worker can stop waiting on
     // it. An in-process loader cannot be killed the way the old subprocess's
-    // process group could, so a load that blows the deadline is abandoned, not
-    // cancelled: it keeps running, and drops `active_query` when it finishes.
-    // The vendored home override is a thread-local set inside `query_daily`, so
-    // it lands on this worker thread — not the caller's.
+    // process group could, so a load that blows the deadline is now *cancelled*
+    // via a flag that the vendored loader polls every ~1k lines. The abandoned
+    // worker will abort soon, free its allocations, and drop `active_query`
+    // before clearing the flag. The vendored home override is a thread-local set
+    // inside `query_daily`, so it lands on this worker thread — not the caller's.
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let _active_query = active_query;
@@ -2054,6 +2063,13 @@ fn run_ccusage_query(opts_json: &str, plugin_id: &str, deadline: ProbeDeadline) 
             pricing_overlay.as_deref(),
         );
         let _ = tx.send(result);
+        // Clear the cancel flag for this provider when the worker exits,
+        // whether via success, error, or cancellation. This allows the next
+        // query to start without inheriting a stale cancel.
+        match provider {
+            CcusageProvider::Claude => ccusage_vendor::set_claude_cancel(false),
+            CcusageProvider::Codex => ccusage_vendor::set_codex_cancel(false),
+        }
     });
 
     match rx.recv_timeout(timeout) {
@@ -2068,10 +2084,14 @@ fn run_ccusage_query(opts_json: &str, plugin_id: &str, deadline: ProbeDeadline) 
         }
         Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
             log::warn!(
-                "[plugin:{}] ccusage query timed out after {:?}; abandoning the load",
+                "[plugin:{}] ccusage query timed out after {:?}; cancelling the load",
                 plugin_id,
                 timeout
             );
+            match provider {
+                CcusageProvider::Claude => ccusage_vendor::set_claude_cancel(true),
+                CcusageProvider::Codex => ccusage_vendor::set_codex_cancel(true),
+            }
             runner_failed()
         }
         Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {

--- a/src-tauri/vendor/ccusage/VENDORING.md
+++ b/src-tauri/vendor/ccusage/VENDORING.md
@@ -639,9 +639,47 @@ single-token edits across `adapter/codex.rs`, `codex_loader.rs` and
 backports: the sidechain dedup (`claude_loader.rs`, item 6), the word-boundary
 matcher (`pricing.rs`, item 7), 1h-cache pricing (`types.rs` + `cost.rs` +
 `claude_loader.rs`, item 8), and the models.dev fallback (`pricing.rs` + new
-`models-dev-pricing.json`, item 9) — so those files are **no longer
+`models-dev-pricing.json`, item 9). Item 10 is the OOM/memory-bounding fix
+(`lib.rs`, `claude_loader.rs`, `codex_loader.rs`, `adapter/codex.rs` — streaming,
+age/size caps, cancellation). So those files are **no longer
 byte-identical to v20.0.2**, by design. `git diff` against a fresh `v20.0.2`
 checkout of every *other* file under "Files taken" is empty.
+
+10. **OOM/memory-bounding fix for large histories** (issue #57). `lib.rs`,
+    `claude_loader.rs`, `codex_loader.rs`, `adapter/codex.rs`.
+
+    With a 57 GB `~/.codex/sessions` history the app was OOM-killed at startup:
+    the vendored loader `fs::read`-ed each session file whole (a single rollout
+    file can be ~1 GB), collected every `CodexTokenUsageEvent` into a
+    `Vec` and only then filtered by the 31-day window. The 15 s host deadline
+    abandoned the thread rather than cancelling it, so it kept allocating past
+    11 GB. Fixed in three layers, all local to this crate and `usagepal`'s
+    `host_api` glue:
+
+    - **Streaming** — `visit_codex_session_file` (`codex_loader.rs`) and
+      `read_daily_usage_file`/`read_usage_file` (`claude_loader.rs`) now use
+      `BufReader::read_until` instead of `fs::read` + `byte_lines`. RSS is one
+      line, not one file. The old `byte_lines` helper is still used elsewhere
+      but not for these hot paths.
+
+    - **Age/size caps** — `lib.rs` adds `should_skip_file_due_to_age_with_since`
+      (skip files whose mtime is before `since - 2 days`; only when the caller
+      asked for a recent window, so `since=None` differential fixtures are
+      untouched) and `enforce_file_size_limit` (keep most-recent files until a
+      1 GB budget, drop the rest with a warning). Both loaders call them after
+      `collect_usage_files` and before fanning out threads. For the 31-day
+      Codex query this typically cuts a 57 GB history to a few hundred MB.
+
+    - **Cancellation** — `lib.rs` exposes `set_claude_cancel`/`set_codex_cancel`
+      and `is_*_cancelled` (global `AtomicBool` per provider, `pub` for
+      `usagepal`'s `host_api`). Every hot loop polls every ~1-2 k lines and
+      returns `Err("cancelled")` promptly. `host_api::run_ccusage_query` clears
+      the flag before spawning, sets it on `recv_timeout`, and the worker clears
+      it on exit. `CcusageQueryGuard` already serialises same-provider loads,
+      so the flag + guard together make timeout actually bound memory.
+
+    `git diff` for these files now shows the streaming, filtering and cancellation
+    changes in addition to the previously recorded edits.
 
 ## Public API (consumed by `usagepal`'s `plugin_engine/ccusage.rs`)
 

--- a/src-tauri/vendor/ccusage/VENDORING.md
+++ b/src-tauri/vendor/ccusage/VENDORING.md
@@ -658,25 +658,33 @@ checkout of every *other* file under "Files taken" is empty.
 
     - **Streaming** — `visit_codex_session_file` (`codex_loader.rs`) and
       `read_daily_usage_file`/`read_usage_file` (`claude_loader.rs`) now use
-      `BufReader::read_until` instead of `fs::read` + `byte_lines`. RSS is one
-      line, not one file. The old `byte_lines` helper is still used elsewhere
-      but not for these hot paths.
+      `BufReader::read_until` instead of `fs::read` + `byte_lines`, via shared
+      helpers `trim_line_ending` + `for_each_line`/`try_for_each_line` in
+      `lib.rs`. RSS is one line, not one file. The old `byte_lines` helper
+      remains for other paths but not these hot ones.
 
     - **Age/size caps** — `lib.rs` adds `should_skip_file_due_to_age_with_since`
       (skip files whose mtime is before `since - 2 days`; only when the caller
       asked for a recent window, so `since=None` differential fixtures are
       untouched) and `enforce_file_size_limit` (keep most-recent files until a
-      1 GB budget, drop the rest with a warning). Both loaders call them after
-      `collect_usage_files` and before fanning out threads. For the 31-day
-      Codex query this typically cuts a 57 GB history to a few hundred MB.
+      1 GB budget, drop the rest with a warning), consolidated behind
+      `apply_file_filters` + `FILE_BUDGET_BYTES` so the four call sites
+      (`claude_loader` ×2, `codex_loader`, `adapter/codex`) share one path.
+      Filters run after `collect_usage_files` and before fanning out threads.
+      For the 31-day Codex query this typically cuts a 57 GB history to a few
+      hundred MB. Internally `is_file_older_than`/`file_mtime_or_epoch` de-dupe
+      the mtime checks.
 
     - **Cancellation** — `lib.rs` exposes `set_claude_cancel`/`set_codex_cancel`
       and `is_*_cancelled` (global `AtomicBool` per provider, `pub` for
-      `usagepal`'s `host_api`). Every hot loop polls every ~1-2 k lines and
-      returns `Err("cancelled")` promptly. `host_api::run_ccusage_query` clears
-      the flag before spawning, sets it on `recv_timeout`, and the worker clears
-      it on exit. `CcusageQueryGuard` already serialises same-provider loads,
-      so the flag + guard together make timeout actually bound memory.
+      `usagepal`'s `host_api`), internally via `set_cancel`/`is_cancelled` and
+      `check_*_cancelled` helpers so the per-file and per-chunk polls share one
+      path (`for_each_line` checks every 1–2 k lines). `host_api` consolidates
+      its three `match provider` blocks behind `set_provider_cancel`.
+      `host_api::run_ccusage_query` clears the flag before spawning, sets it on
+      `recv_timeout`, and the worker clears it on exit. `CcusageQueryGuard`
+      already serialises same-provider loads, so the flag + guard together make
+      timeout actually bound memory.
 
     `git diff` for these files now shows the streaming, filtering and cancellation
     changes in addition to the previously recorded edits.

--- a/src-tauri/vendor/ccusage/src/adapter/codex.rs
+++ b/src-tauri/vendor/ccusage/src/adapter/codex.rs
@@ -106,28 +106,8 @@ fn load_groups_from_directory_with_dedupe(
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let mut files = Vec::new();
     crate::collect_usage_files(sessions_dir, &mut files);
-    // Coarse pre-filter: drop files not modified in the last 32 days. For the
-    // 31-day window the plugin queries, this can cut a 57 GB history to a few
-    // hundred MB without touching record timestamps (which remain authoritative).
-    // Only when the caller asked for a recent window; the differential gate
-    // queries with since=None and must see all fixtures.
-    let before_filter = files.len();
-    files.retain(|p| !crate::should_skip_file_due_to_age_with_since(p, shared.since.as_deref()));
-    if files.len() != before_filter {
-        ::log::info!(
-            "codex: filtered {} files by age ({} -> {})",
-            before_filter - files.len(),
-            before_filter,
-            files.len()
-        );
-    }
-    // Hard budget: cap total bytes to keep RSS bounded even if recent history
-    // is huge (e.g. a single 1 GB rollout file). Most-recent files win.
-    crate::enforce_file_size_limit(&mut files, 1_000_000_000);
-    // Also respect cancellation before fanning out threads.
-    if crate::is_codex_cancelled() {
-        return Err(crate::cli_error("cancelled"));
-    }
+    crate::apply_file_filters(&mut files, shared.since.as_deref(), "codex");
+    crate::check_codex_cancelled()?;
     if shared.single_thread {
         return aggregate_files(sessions_dir, &files, shared, kind, seen);
     }
@@ -144,9 +124,7 @@ fn aggregate_files(
     let mut groups = BTreeMap::new();
     let timezone = parse_tz(shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
     for file in files {
-        if crate::is_codex_cancelled() {
-            return Err(crate::cli_error("cancelled"));
-        }
+        crate::check_codex_cancelled()?;
         aggregate_file(
             sessions_dir,
             file,
@@ -184,9 +162,7 @@ fn aggregate_files_parallel(
                 let timezone =
                     parse_tz(shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
                 for index in chunk {
-                    if crate::is_codex_cancelled() {
-                        return Err(crate::cli_error("cancelled"));
-                    }
+                    crate::check_codex_cancelled()?;
                     aggregate_file(
                         sessions_dir,
                         &files[index],

--- a/src-tauri/vendor/ccusage/src/adapter/codex.rs
+++ b/src-tauri/vendor/ccusage/src/adapter/codex.rs
@@ -106,6 +106,28 @@ fn load_groups_from_directory_with_dedupe(
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let mut files = Vec::new();
     crate::collect_usage_files(sessions_dir, &mut files);
+    // Coarse pre-filter: drop files not modified in the last 32 days. For the
+    // 31-day window the plugin queries, this can cut a 57 GB history to a few
+    // hundred MB without touching record timestamps (which remain authoritative).
+    // Only when the caller asked for a recent window; the differential gate
+    // queries with since=None and must see all fixtures.
+    let before_filter = files.len();
+    files.retain(|p| !crate::should_skip_file_due_to_age_with_since(p, shared.since.as_deref()));
+    if files.len() != before_filter {
+        ::log::info!(
+            "codex: filtered {} files by age ({} -> {})",
+            before_filter - files.len(),
+            before_filter,
+            files.len()
+        );
+    }
+    // Hard budget: cap total bytes to keep RSS bounded even if recent history
+    // is huge (e.g. a single 1 GB rollout file). Most-recent files win.
+    crate::enforce_file_size_limit(&mut files, 1_000_000_000);
+    // Also respect cancellation before fanning out threads.
+    if crate::is_codex_cancelled() {
+        return Err(crate::cli_error("cancelled"));
+    }
     if shared.single_thread {
         return aggregate_files(sessions_dir, &files, shared, kind, seen);
     }
@@ -122,6 +144,9 @@ fn aggregate_files(
     let mut groups = BTreeMap::new();
     let timezone = parse_tz(shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
     for file in files {
+        if crate::is_codex_cancelled() {
+            return Err(crate::cli_error("cancelled"));
+        }
         aggregate_file(
             sessions_dir,
             file,
@@ -159,6 +184,9 @@ fn aggregate_files_parallel(
                 let timezone =
                     parse_tz(shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
                 for index in chunk {
+                    if crate::is_codex_cancelled() {
+                        return Err(crate::cli_error("cancelled"));
+                    }
                     aggregate_file(
                         sessions_dir,
                         &files[index],

--- a/src-tauri/vendor/ccusage/src/claude_loader.rs
+++ b/src-tauri/vendor/ccusage/src/claude_loader.rs
@@ -2,6 +2,7 @@ use std::{
     collections::BTreeMap,
     env, fs,
     hash::{Hash, Hasher},
+    io::{BufRead, BufReader},
     path::{Path, PathBuf},
     sync::Arc,
     thread,
@@ -47,7 +48,24 @@ fn load_daily_summaries_inner(
     group_by_project: bool,
 ) -> Result<Vec<UsageSummary>> {
     let paths = claude_paths()?;
-    let files = usage_files(&paths, project_filter);
+    let mut files = usage_files(&paths, project_filter);
+    // Pre-filter by mtime to avoid scanning years of history for a 31-day window.
+    // Only when the caller asked for a recent window (since is Some); the
+    // differential gate and other tests query with since=None and must see all fixtures.
+    let before = files.len();
+    files.retain(|p| !crate::should_skip_file_due_to_age_with_since(p, shared.since.as_deref()));
+    if files.len() != before {
+        ::log::info!(
+            "claude: filtered {} files by age ({} -> {})",
+            before - files.len(),
+            before,
+            files.len()
+        );
+    }
+    crate::enforce_file_size_limit(&mut files, 1_000_000_000);
+    if crate::is_claude_cancelled() {
+        return Err(crate::cli_error("cancelled"));
+    }
     if files.is_empty() {
         return Ok(Vec::new());
     }
@@ -133,8 +151,22 @@ fn load_entries_inner(
                 .join(", ")
         ),
     );
-    let files = usage_files(&paths, project_filter);
+    let mut files = usage_files(&paths, project_filter);
     debug_log(shared, format!("Found {} JSONL usage files", files.len()));
+    let before = files.len();
+    files.retain(|p| !crate::should_skip_file_due_to_age_with_since(p, shared.since.as_deref()));
+    if files.len() != before {
+        ::log::info!(
+            "claude: filtered {} files by age ({} -> {})",
+            before - files.len(),
+            before,
+            files.len()
+        );
+    }
+    crate::enforce_file_size_limit(&mut files, 1_000_000_000);
+    if crate::is_claude_cancelled() {
+        return Err(crate::cli_error("cancelled"));
+    }
     if files.is_empty() {
         return Ok(Vec::new());
     }
@@ -419,12 +451,36 @@ fn read_daily_usage_file(
         timestamp: None,
         entries: Vec::new(),
     };
-    let Ok(content) = fs::read(path) else {
+    let Ok(file) = fs::File::open(path) else {
         return loaded_file;
     };
+    let mut reader = BufReader::new(file);
+    let mut line = Vec::new();
+    let mut line_count: usize = 0;
 
     let usage_marker = memmem::Finder::new(br#""usage":{"#);
-    for line in byte_lines(&content) {
+    loop {
+        line.clear();
+        let n = match reader.read_until(b'\n', &mut line) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => break,
+        };
+        let mut slice: &[u8] = &line;
+        if slice.ends_with(b"\n") {
+            slice = &slice[..slice.len() - 1];
+            if slice.ends_with(b"\r") {
+                slice = &slice[..slice.len() - 1];
+            }
+        }
+        line_count += 1;
+        if line_count % 2048 == 0 && crate::is_claude_cancelled() {
+            break;
+        }
+        if n == 0 {
+            break;
+        }
+        let line = slice;
         if usage_marker.find(line).is_none() {
             continue;
         }
@@ -747,12 +803,36 @@ fn read_usage_file(
         timestamp: None,
         entries: Vec::new(),
     };
-    let Ok(content) = fs::read(path) else {
+    let Ok(file) = fs::File::open(path) else {
         return loaded_file;
     };
+    let mut reader = BufReader::new(file);
+    let mut line = Vec::new();
+    let mut line_count: usize = 0;
 
     let usage_marker = memmem::Finder::new(br#""usage":{"#);
-    for line in byte_lines(&content) {
+    loop {
+        line.clear();
+        let n = match reader.read_until(b'\n', &mut line) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => break,
+        };
+        let mut slice: &[u8] = &line;
+        if slice.ends_with(b"\n") {
+            slice = &slice[..slice.len() - 1];
+            if slice.ends_with(b"\r") {
+                slice = &slice[..slice.len() - 1];
+            }
+        }
+        line_count += 1;
+        if line_count % 2048 == 0 && crate::is_claude_cancelled() {
+            break;
+        }
+        if n == 0 {
+            break;
+        }
+        let line = slice;
         if usage_marker.find(line).is_none() {
             continue;
         }

--- a/src-tauri/vendor/ccusage/src/claude_loader.rs
+++ b/src-tauri/vendor/ccusage/src/claude_loader.rs
@@ -2,7 +2,6 @@ use std::{
     collections::BTreeMap,
     env, fs,
     hash::{Hash, Hasher},
-    io::{BufRead, BufReader},
     path::{Path, PathBuf},
     sync::Arc,
     thread,
@@ -17,7 +16,7 @@ use crate::{
     calculate_cost, calculate_cost_for_usage,
     cli::{CostMode, SharedArgs},
     cli_error, debug_log,
-    fast::{byte_lines, suffix_string, FxHashMap, FxHashSet, SmallIndexVec},
+    fast::{suffix_string, FxHashMap, FxHashSet, SmallIndexVec},
     format_date_tz, home, log_level, parse_ts_timestamp, parse_tz, progress, LoadedEntry,
     LoadedFile, ModelBreakdown, PricingMap, Result, Speed, TimestampMs, TokenCounts, TokenUsageRaw,
     UsageEntry, UsageSummary,
@@ -49,23 +48,8 @@ fn load_daily_summaries_inner(
 ) -> Result<Vec<UsageSummary>> {
     let paths = claude_paths()?;
     let mut files = usage_files(&paths, project_filter);
-    // Pre-filter by mtime to avoid scanning years of history for a 31-day window.
-    // Only when the caller asked for a recent window (since is Some); the
-    // differential gate and other tests query with since=None and must see all fixtures.
-    let before = files.len();
-    files.retain(|p| !crate::should_skip_file_due_to_age_with_since(p, shared.since.as_deref()));
-    if files.len() != before {
-        ::log::info!(
-            "claude: filtered {} files by age ({} -> {})",
-            before - files.len(),
-            before,
-            files.len()
-        );
-    }
-    crate::enforce_file_size_limit(&mut files, 1_000_000_000);
-    if crate::is_claude_cancelled() {
-        return Err(crate::cli_error("cancelled"));
-    }
+    crate::apply_file_filters(&mut files, shared.since.as_deref(), "claude");
+    crate::check_claude_cancelled()?;
     if files.is_empty() {
         return Ok(Vec::new());
     }
@@ -153,20 +137,8 @@ fn load_entries_inner(
     );
     let mut files = usage_files(&paths, project_filter);
     debug_log(shared, format!("Found {} JSONL usage files", files.len()));
-    let before = files.len();
-    files.retain(|p| !crate::should_skip_file_due_to_age_with_since(p, shared.since.as_deref()));
-    if files.len() != before {
-        ::log::info!(
-            "claude: filtered {} files by age ({} -> {})",
-            before - files.len(),
-            before,
-            files.len()
-        );
-    }
-    crate::enforce_file_size_limit(&mut files, 1_000_000_000);
-    if crate::is_claude_cancelled() {
-        return Err(crate::cli_error("cancelled"));
-    }
+    crate::apply_file_filters(&mut files, shared.since.as_deref(), "claude");
+    crate::check_claude_cancelled()?;
     if files.is_empty() {
         return Ok(Vec::new());
     }
@@ -451,48 +423,20 @@ fn read_daily_usage_file(
         timestamp: None,
         entries: Vec::new(),
     };
-    let Ok(file) = fs::File::open(path) else {
-        return loaded_file;
-    };
-    let mut reader = BufReader::new(file);
-    let mut line = Vec::new();
-    let mut line_count: usize = 0;
-
     let usage_marker = memmem::Finder::new(br#""usage":{"#);
-    loop {
-        line.clear();
-        let n = match reader.read_until(b'\n', &mut line) {
-            Ok(0) => break,
-            Ok(n) => n,
-            Err(_) => break,
-        };
-        let mut slice: &[u8] = &line;
-        if slice.ends_with(b"\n") {
-            slice = &slice[..slice.len() - 1];
-            if slice.ends_with(b"\r") {
-                slice = &slice[..slice.len() - 1];
-            }
-        }
-        line_count += 1;
-        if line_count % 2048 == 0 && crate::is_claude_cancelled() {
-            break;
-        }
-        if n == 0 {
-            break;
-        }
-        let line = slice;
+    crate::for_each_line(path, 2048, crate::is_claude_cancelled, |line| {
         if usage_marker.find(line).is_none() {
-            continue;
+            return;
         }
         if has_unsupported_null_field(line) {
-            continue;
+            return;
         }
         let Ok(data) = serde_json::from_slice::<DailyUsageLine>(line) else {
-            continue;
+            return;
         };
         let data = data.into_entry();
         let Some(timestamp) = parse_ts_timestamp(&data.timestamp) else {
-            continue;
+            return;
         };
         loaded_file.timestamp = Some(
             loaded_file
@@ -500,7 +444,7 @@ fn read_daily_usage_file(
                 .map_or(timestamp, |current| current.min(timestamp)),
         );
         if !is_valid_daily_usage_entry(&data) {
-            continue;
+            return;
         }
         let usage = data.message.usage;
         let cost = calculate_cost_for_usage(
@@ -529,7 +473,7 @@ fn read_daily_usage_file(
             request_id: data.request_id,
             is_sidechain: data.is_sidechain,
         });
-    }
+    });
     loaded_file
 }
 
@@ -803,51 +747,23 @@ fn read_usage_file(
         timestamp: None,
         entries: Vec::new(),
     };
-    let Ok(file) = fs::File::open(path) else {
-        return loaded_file;
-    };
-    let mut reader = BufReader::new(file);
-    let mut line = Vec::new();
-    let mut line_count: usize = 0;
-
     let usage_marker = memmem::Finder::new(br#""usage":{"#);
-    loop {
-        line.clear();
-        let n = match reader.read_until(b'\n', &mut line) {
-            Ok(0) => break,
-            Ok(n) => n,
-            Err(_) => break,
-        };
-        let mut slice: &[u8] = &line;
-        if slice.ends_with(b"\n") {
-            slice = &slice[..slice.len() - 1];
-            if slice.ends_with(b"\r") {
-                slice = &slice[..slice.len() - 1];
-            }
-        }
-        line_count += 1;
-        if line_count % 2048 == 0 && crate::is_claude_cancelled() {
-            break;
-        }
-        if n == 0 {
-            break;
-        }
-        let line = slice;
+    crate::for_each_line(path, 2048, crate::is_claude_cancelled, |line| {
         if usage_marker.find(line).is_none() {
-            continue;
+            return;
         }
         if has_unsupported_null_field(line) {
-            continue;
+            return;
         }
         let Ok(data) = serde_json::from_slice::<UsageEntry>(line) else {
-            continue;
+            return;
         };
         let Some(timestamp) = parse_ts_timestamp(&data.timestamp) else {
-            continue;
+            return;
         };
         update_loaded_file_timestamp(&mut loaded_file, timestamp);
         if !is_valid_usage_entry(&data) {
-            continue;
+            return;
         }
         let date = format_date_tz(timestamp, tz);
         let cost = calculate_cost(&data, mode, pricing);
@@ -876,7 +792,7 @@ fn read_usage_file(
             model,
             usage_limit_reset_time,
         });
-    }
+    });
     loaded_file
 }
 

--- a/src-tauri/vendor/ccusage/src/codex_loader.rs
+++ b/src-tauri/vendor/ccusage/src/codex_loader.rs
@@ -1,9 +1,4 @@
-use std::{
-    env, fs,
-    io::{BufRead, BufReader},
-    path::{Path, PathBuf},
-    thread,
-};
+use std::{env, fs, path::{Path, PathBuf}, thread};
 
 use compact_str::CompactString;
 use serde_json::Value;
@@ -12,7 +7,7 @@ use crate::{
     chunk_file_indexes_by_size,
     cli::SharedArgs,
     cli_error, collect_usage_files,
-    fast::{byte_lines, FxHashSet},
+    fast::FxHashSet,
     home, non_empty_json_string, progress, CodexRawUsage, CodexTokenUsageEvent, Result,
     TimestampMs,
 };
@@ -23,20 +18,8 @@ pub(crate) fn load_codex_events_from_directory(
 ) -> Result<Vec<CodexTokenUsageEvent>> {
     let mut files = Vec::new();
     collect_usage_files(sessions_dir, &mut files);
-    let before = files.len();
-    files.retain(|p| !crate::should_skip_file_due_to_age_with_since(p, None));
-    if files.len() != before {
-        ::log::info!(
-            "codex_loader: filtered {} files by age ({} -> {})",
-            before - files.len(),
-            before,
-            files.len()
-        );
-    }
-    crate::enforce_file_size_limit(&mut files, 1_000_000_000);
-    if crate::is_codex_cancelled() {
-        return Err(crate::cli_error("cancelled"));
-    }
+    crate::apply_file_filters(&mut files, None, "codex_loader");
+    crate::check_codex_cancelled()?;
     let mut events = if single_thread {
         files
             .iter()
@@ -154,56 +137,19 @@ pub(crate) fn visit_codex_session_file(
     path: &Path,
     mut visit: impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
-    // Stream the file instead of `fs::read`-ing it whole: a single rollout file
-    // can be ~1 GB, and the old path allocated that plus a second copy via
-    // `byte_lines`. Streaming caps RSS to one line at a time and lets us abort
-    // promptly when the host's 15s deadline fires.
-    let file = match fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return Ok(()),
-    };
-    let mut reader = BufReader::new(file);
-    let mut line = Vec::new();
-    let mut line_count: usize = 0;
     let session_id = codex_session_id(sessions_dir, path);
     let mut previous_totals: Option<CodexRawUsage> = None;
     let mut current_model: Option<String> = None;
     let mut current_model_is_fallback = false;
-    // Tracks the service tier applied to subsequent turns. Codex records tier
-    // changes as `thread_settings_applied` events, so fast pricing is scoped to
-    // the turns that actually ran fast rather than the whole session/history.
     let mut current_fast_tier = false;
     let fallback_timestamp = file_modified_timestamp(path);
 
-    loop {
-        line.clear();
-        let n = match reader.read_until(b'\n', &mut line) {
-            Ok(0) => break,
-            Ok(n) => n,
-            Err(_) => break,
-        };
-        // Trim trailing newline(s) so downstream `from_slice` sees the same bytes
-        // as the old `byte_lines` iterator did.
-        let mut line_slice: &[u8] = &line;
-        if line_slice.ends_with(b"\n") {
-            line_slice = &line_slice[..line_slice.len() - 1];
-            if line_slice.ends_with(b"\r") {
-                line_slice = &line_slice[..line_slice.len() - 1];
-            }
-        }
-        line_count += 1;
-        if line_count % 1024 == 0 && crate::is_codex_cancelled() {
-            return Err(crate::cli_error("cancelled"));
-        }
-        if n == 0 {
-            break;
-        }
-        let line = line_slice;
+    let cancelled = crate::try_for_each_line(path, 1024, crate::is_codex_cancelled, |line| {
         if !codex_line_may_contain_usage(line) {
-            continue;
+            return Ok(());
         }
         let Ok(value) = serde_json::from_slice::<Value>(line) else {
-            continue;
+            return Ok(());
         };
         let entry_type = value.get("type").and_then(Value::as_str);
         if entry_type == Some("turn_context") {
@@ -214,7 +160,7 @@ pub(crate) fn visit_codex_session_file(
             if let Some(fast) = codex_thread_settings_fast_tier(&value) {
                 current_fast_tier = fast;
             }
-            continue;
+            return Ok(());
         }
         if entry_type == Some("thread_settings_applied")
             || codex_payload_type_is(&value, "thread_settings_applied")
@@ -222,7 +168,7 @@ pub(crate) fn visit_codex_session_file(
             if let Some(fast) = codex_thread_settings_fast_tier(&value) {
                 current_fast_tier = fast;
             }
-            continue;
+            return Ok(());
         }
         if entry_type != Some("event_msg") {
             add_codex_exec_event(
@@ -234,16 +180,16 @@ pub(crate) fn visit_codex_session_file(
                 current_fast_tier,
                 &mut visit,
             )?;
-            continue;
+            return Ok(());
         }
         let Some(timestamp) = value.get("timestamp").and_then(Value::as_str) else {
-            continue;
+            return Ok(());
         };
         let Some(payload) = value.get("payload") else {
-            continue;
+            return Ok(());
         };
         if payload.get("type").and_then(Value::as_str) != Some("token_count") {
-            continue;
+            return Ok(());
         }
         let info = payload.get("info");
         let total_usage = info.and_then(|info| {
@@ -264,14 +210,14 @@ pub(crate) fn visit_codex_session_file(
             previous_totals = Some(total_usage);
         }
         let Some(raw_usage) = raw_usage else {
-            continue;
+            return Ok(());
         };
         if raw_usage.input_tokens == 0
             && raw_usage.cached_input_tokens == 0
             && raw_usage.output_tokens == 0
             && raw_usage.reasoning_output_tokens == 0
         {
-            continue;
+            return Ok(());
         }
 
         let parsed_model = codex_model_from_payload(Some(payload))
@@ -303,8 +249,12 @@ pub(crate) fn visit_codex_session_file(
             is_fallback_model,
             is_fast_tier: current_fast_tier,
         })?;
-    }
+        Ok(())
+    })?;
 
+    if cancelled {
+        return Err(crate::cli_error("cancelled"));
+    }
     Ok(())
 }
 

--- a/src-tauri/vendor/ccusage/src/codex_loader.rs
+++ b/src-tauri/vendor/ccusage/src/codex_loader.rs
@@ -1,5 +1,6 @@
 use std::{
     env, fs,
+    io::{BufRead, BufReader},
     path::{Path, PathBuf},
     thread,
 };
@@ -22,6 +23,20 @@ pub(crate) fn load_codex_events_from_directory(
 ) -> Result<Vec<CodexTokenUsageEvent>> {
     let mut files = Vec::new();
     collect_usage_files(sessions_dir, &mut files);
+    let before = files.len();
+    files.retain(|p| !crate::should_skip_file_due_to_age_with_since(p, None));
+    if files.len() != before {
+        ::log::info!(
+            "codex_loader: filtered {} files by age ({} -> {})",
+            before - files.len(),
+            before,
+            files.len()
+        );
+    }
+    crate::enforce_file_size_limit(&mut files, 1_000_000_000);
+    if crate::is_codex_cancelled() {
+        return Err(crate::cli_error("cancelled"));
+    }
     let mut events = if single_thread {
         files
             .iter()
@@ -139,9 +154,17 @@ pub(crate) fn visit_codex_session_file(
     path: &Path,
     mut visit: impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
-    let Ok(content) = fs::read(path) else {
-        return Ok(());
+    // Stream the file instead of `fs::read`-ing it whole: a single rollout file
+    // can be ~1 GB, and the old path allocated that plus a second copy via
+    // `byte_lines`. Streaming caps RSS to one line at a time and lets us abort
+    // promptly when the host's 15s deadline fires.
+    let file = match fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Ok(()),
     };
+    let mut reader = BufReader::new(file);
+    let mut line = Vec::new();
+    let mut line_count: usize = 0;
     let session_id = codex_session_id(sessions_dir, path);
     let mut previous_totals: Option<CodexRawUsage> = None;
     let mut current_model: Option<String> = None;
@@ -152,7 +175,30 @@ pub(crate) fn visit_codex_session_file(
     let mut current_fast_tier = false;
     let fallback_timestamp = file_modified_timestamp(path);
 
-    for line in byte_lines(&content) {
+    loop {
+        line.clear();
+        let n = match reader.read_until(b'\n', &mut line) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => break,
+        };
+        // Trim trailing newline(s) so downstream `from_slice` sees the same bytes
+        // as the old `byte_lines` iterator did.
+        let mut line_slice: &[u8] = &line;
+        if line_slice.ends_with(b"\n") {
+            line_slice = &line_slice[..line_slice.len() - 1];
+            if line_slice.ends_with(b"\r") {
+                line_slice = &line_slice[..line_slice.len() - 1];
+            }
+        }
+        line_count += 1;
+        if line_count % 1024 == 0 && crate::is_codex_cancelled() {
+            return Err(crate::cli_error("cancelled"));
+        }
+        if n == 0 {
+            break;
+        }
+        let line = line_slice;
         if !codex_line_may_contain_usage(line) {
             continue;
         }

--- a/src-tauri/vendor/ccusage/src/lib.rs
+++ b/src-tauri/vendor/ccusage/src/lib.rs
@@ -53,7 +53,16 @@ mod terminal_stub;
 mod types;
 mod utils;
 
-use std::{cell::RefCell, env::VarError, ffi::OsString, fmt, path::Path, sync::Arc};
+use std::{
+    cell::RefCell,
+    env::VarError,
+    ffi::OsString,
+    fmt,
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use serde_json::json;
 
@@ -272,6 +281,136 @@ impl PricingTable {
 // override is always visible where it is read, and is invisible to every other
 // thread in the process.
 // ---------------------------------------------------------------------------
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static CLAUDE_CANCEL: AtomicBool = AtomicBool::new(false);
+static CODEX_CANCEL: AtomicBool = AtomicBool::new(false);
+
+pub fn set_claude_cancel(v: bool) {
+    CLAUDE_CANCEL.store(v, Ordering::Relaxed);
+}
+
+pub fn set_codex_cancel(v: bool) {
+    CODEX_CANCEL.store(v, Ordering::Relaxed);
+}
+
+pub(crate) fn is_claude_cancelled() -> bool {
+    CLAUDE_CANCEL.load(Ordering::Relaxed)
+}
+
+pub(crate) fn is_codex_cancelled() -> bool {
+    CODEX_CANCEL.load(Ordering::Relaxed)
+}
+
+/// Whether a file should be skipped because it is too old to contain data
+/// for the 31-day window the app queries. Codex and Claude session files are
+/// append-only, so a file not modified in 32 days cannot contain a recent
+/// event. This is a coarse pre-filter; the per-record timestamp filter remains
+/// authoritative for Today/Yesterday/30d totals.
+pub(crate) fn should_skip_file_due_to_age(path: &Path) -> bool {
+    const CUTOFF_DAYS: u64 = 32;
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    let Ok(modified) = metadata.modified() else {
+        return false;
+    };
+    let Ok(age) = SystemTime::now().duration_since(modified) else {
+        return false;
+    };
+    age > Duration::from_secs(CUTOFF_DAYS * 24 * 3600)
+}
+
+pub(crate) fn should_skip_file_due_to_age_with_since(path: &Path, since: Option<&str>) -> bool {
+    let Some(since_str) = since else {
+        return false;
+    };
+    // Parse YYYYMMDD to SystemTime at 00:00 UTC, then subtract 2 days slop.
+    // If parsing fails, fall back to the 32-day cutoff.
+    let cutoff = parse_since_to_system_time(since_str)
+        .and_then(|t| t.checked_sub(Duration::from_secs(2 * 24 * 3600)))
+        .unwrap_or_else(|| {
+            SystemTime::now()
+                .checked_sub(Duration::from_secs(32 * 24 * 3600))
+                .unwrap_or(UNIX_EPOCH)
+        });
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    let Ok(modified) = metadata.modified() else {
+        return false;
+    };
+    // If file was modified before the cutoff, it cannot contain data for the
+    // requested window (files are append-only, mtime ~ last event).
+    match modified.duration_since(cutoff) {
+        Ok(_) => false, // modified >= cutoff, keep
+        Err(_) => true,  // modified < cutoff, skip
+    }
+}
+
+fn parse_since_to_system_time(since: &str) -> Option<SystemTime> {
+    if since.len() != 8 {
+        return None;
+    }
+    let year: i32 = since[0..4].parse().ok()?;
+    let month: u32 = since[4..6].parse().ok()?;
+    let day: u32 = since[6..8].parse().ok()?;
+    // Use jiff to handle leap years etc., then convert to SystemTime.
+    let date = jiff::civil::Date::new(year as i16, month as i8, day as i8).ok()?;
+    let zoned = date.to_zoned(jiff::tz::TimeZone::UTC).ok()?;
+    let secs = zoned.timestamp().as_second();
+    if secs < 0 {
+        return None;
+    }
+    Some(UNIX_EPOCH + Duration::from_secs(secs as u64))
+}
+
+/// Enforce a hard budget on the number of bytes we will read. Files are
+/// assumed to have been collected already; this sorts them most-recent first
+/// (by mtime) and keeps the prefix that fits within `max_bytes`. The rest are
+/// dropped with a warning. This caps RSS when a user has a multi-GB history.
+pub(crate) fn enforce_file_size_limit(files: &mut Vec<PathBuf>, max_bytes: u64) {
+    if files.is_empty() {
+        return;
+    }
+    // Sort most-recent first so we keep the data the UI actually needs.
+    files.sort_by(|a, b| {
+        let ma = fs::metadata(a)
+            .and_then(|m| m.modified())
+            .unwrap_or(UNIX_EPOCH);
+        let mb = fs::metadata(b)
+            .and_then(|m| m.modified())
+            .unwrap_or(UNIX_EPOCH);
+        mb.cmp(&ma)
+    });
+
+    let mut total: u64 = 0;
+    let mut kept: Vec<PathBuf> = Vec::with_capacity(files.len());
+    let mut skipped_bytes: u64 = 0;
+    let mut skipped_count: usize = 0;
+    for path in files.drain(..) {
+        let size = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        if total + size > max_bytes && !kept.is_empty() {
+            skipped_bytes += size;
+            skipped_count += 1;
+            continue;
+        }
+        total += size;
+        kept.push(path);
+    }
+    if skipped_count > 0 {
+        ::log::warn!(
+            "ccusage: skipped {} files ({} bytes) beyond {}-byte budget; kept {} files ({} bytes)",
+            skipped_count,
+            skipped_bytes,
+            max_bytes,
+            kept.len(),
+            total
+        );
+    }
+    *files = kept;
+}
 
 thread_local! {
     static HOME_OVERRIDE: RefCell<Option<(&'static str, OsString)>> = const { RefCell::new(None) };

--- a/src-tauri/vendor/ccusage/src/lib.rs
+++ b/src-tauri/vendor/ccusage/src/lib.rs
@@ -59,6 +59,7 @@ use std::{
     ffi::OsString,
     fmt,
     fs,
+    io::{BufRead, BufReader},
     path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -287,20 +288,57 @@ use std::sync::atomic::{AtomicBool, Ordering};
 static CLAUDE_CANCEL: AtomicBool = AtomicBool::new(false);
 static CODEX_CANCEL: AtomicBool = AtomicBool::new(false);
 
+fn set_cancel(flag: &AtomicBool, v: bool) {
+    flag.store(v, Ordering::Relaxed);
+}
+
+fn is_cancelled(flag: &AtomicBool) -> bool {
+    flag.load(Ordering::Relaxed)
+}
+
 pub fn set_claude_cancel(v: bool) {
-    CLAUDE_CANCEL.store(v, Ordering::Relaxed);
+    set_cancel(&CLAUDE_CANCEL, v);
 }
 
 pub fn set_codex_cancel(v: bool) {
-    CODEX_CANCEL.store(v, Ordering::Relaxed);
+    set_cancel(&CODEX_CANCEL, v);
 }
 
 pub(crate) fn is_claude_cancelled() -> bool {
-    CLAUDE_CANCEL.load(Ordering::Relaxed)
+    is_cancelled(&CLAUDE_CANCEL)
 }
 
 pub(crate) fn is_codex_cancelled() -> bool {
-    CODEX_CANCEL.load(Ordering::Relaxed)
+    is_cancelled(&CODEX_CANCEL)
+}
+
+pub(crate) fn check_claude_cancelled() -> Result<()> {
+    if is_claude_cancelled() {
+        Err(cli_error("cancelled"))
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn check_codex_cancelled() -> Result<()> {
+    if is_codex_cancelled() {
+        Err(cli_error("cancelled"))
+    } else {
+        Ok(())
+    }
+}
+
+fn file_mtime_or_epoch(path: &Path) -> SystemTime {
+    fs::metadata(path)
+        .and_then(|m| m.modified())
+        .unwrap_or(UNIX_EPOCH)
+}
+
+fn is_file_older_than(path: &Path, cutoff: SystemTime) -> bool {
+    let Ok(modified) = fs::metadata(path).and_then(|m| m.modified()) else {
+        return false;
+    };
+    modified < cutoff
 }
 
 /// Whether a file should be skipped because it is too old to contain data
@@ -310,16 +348,10 @@ pub(crate) fn is_codex_cancelled() -> bool {
 /// authoritative for Today/Yesterday/30d totals.
 pub(crate) fn should_skip_file_due_to_age(path: &Path) -> bool {
     const CUTOFF_DAYS: u64 = 32;
-    let Ok(metadata) = fs::metadata(path) else {
-        return false;
-    };
-    let Ok(modified) = metadata.modified() else {
-        return false;
-    };
-    let Ok(age) = SystemTime::now().duration_since(modified) else {
-        return false;
-    };
-    age > Duration::from_secs(CUTOFF_DAYS * 24 * 3600)
+    let cutoff = SystemTime::now()
+        .checked_sub(Duration::from_secs(CUTOFF_DAYS * 24 * 3600))
+        .unwrap_or(UNIX_EPOCH);
+    is_file_older_than(path, cutoff)
 }
 
 pub(crate) fn should_skip_file_due_to_age_with_since(path: &Path, since: Option<&str>) -> bool {
@@ -335,18 +367,7 @@ pub(crate) fn should_skip_file_due_to_age_with_since(path: &Path, since: Option<
                 .checked_sub(Duration::from_secs(32 * 24 * 3600))
                 .unwrap_or(UNIX_EPOCH)
         });
-    let Ok(metadata) = fs::metadata(path) else {
-        return false;
-    };
-    let Ok(modified) = metadata.modified() else {
-        return false;
-    };
-    // If file was modified before the cutoff, it cannot contain data for the
-    // requested window (files are append-only, mtime ~ last event).
-    match modified.duration_since(cutoff) {
-        Ok(_) => false, // modified >= cutoff, keep
-        Err(_) => true,  // modified < cutoff, skip
-    }
+    is_file_older_than(path, cutoff)
 }
 
 fn parse_since_to_system_time(since: &str) -> Option<SystemTime> {
@@ -366,24 +387,16 @@ fn parse_since_to_system_time(since: &str) -> Option<SystemTime> {
     Some(UNIX_EPOCH + Duration::from_secs(secs as u64))
 }
 
-/// Enforce a hard budget on the number of bytes we will read. Files are
-/// assumed to have been collected already; this sorts them most-recent first
-/// (by mtime) and keeps the prefix that fits within `max_bytes`. The rest are
-/// dropped with a warning. This caps RSS when a user has a multi-GB history.
+/// Hard budget: keep most-recent files until `max_bytes`, drop the rest.
+/// Shared by Claude and Codex loaders — sorts by mtime (recent first) so the
+/// window the UI needs is preserved.
+pub(crate) const FILE_BUDGET_BYTES: u64 = 1_000_000_000;
+
 pub(crate) fn enforce_file_size_limit(files: &mut Vec<PathBuf>, max_bytes: u64) {
     if files.is_empty() {
         return;
     }
-    // Sort most-recent first so we keep the data the UI actually needs.
-    files.sort_by(|a, b| {
-        let ma = fs::metadata(a)
-            .and_then(|m| m.modified())
-            .unwrap_or(UNIX_EPOCH);
-        let mb = fs::metadata(b)
-            .and_then(|m| m.modified())
-            .unwrap_or(UNIX_EPOCH);
-        mb.cmp(&ma)
-    });
+    files.sort_by(|a, b| file_mtime_or_epoch(b).cmp(&file_mtime_or_epoch(a)));
 
     let mut total: u64 = 0;
     let mut kept: Vec<PathBuf> = Vec::with_capacity(files.len());
@@ -410,6 +423,93 @@ pub(crate) fn enforce_file_size_limit(files: &mut Vec<PathBuf>, max_bytes: u64) 
         );
     }
     *files = kept;
+}
+
+/// Apply the coarse mtime pre-filter and the byte-budget cap. Only filters by
+/// age when `since` is Some (the 31-day query); `None` keeps all fixtures for
+/// differential tests. Logs when files are dropped.
+pub(crate) fn apply_file_filters(
+    files: &mut Vec<PathBuf>,
+    since: Option<&str>,
+    label: &str,
+) {
+    let before = files.len();
+    files.retain(|p| !should_skip_file_due_to_age_with_since(p, since));
+    if files.len() != before {
+        ::log::info!(
+            "{}: filtered {} files by age ({} -> {})",
+            label,
+            before - files.len(),
+            before,
+            files.len()
+        );
+    }
+    enforce_file_size_limit(files, FILE_BUDGET_BYTES);
+}
+
+pub(crate) fn trim_line_ending(line: &[u8]) -> &[u8] {
+    if line.ends_with(b"\n") {
+        let mut s = &line[..line.len() - 1];
+        if s.ends_with(b"\r") {
+            s = &s[..s.len() - 1];
+        }
+        s
+    } else {
+        line
+    }
+}
+
+/// Stream a file line-by-line with periodic cancellation polling. Opens the
+/// file (silently ignores missing files), then calls `visit` for each trimmed
+/// line. Returns `true` if cancellation was observed and the stream was
+/// aborted early; the caller decides whether that is a `break` (Claude's
+/// partial-file) or an `Err("cancelled")` (Codex's fail-fast).
+pub(crate) fn for_each_line(
+    path: &Path,
+    cancel_every: usize,
+    is_cancelled: impl Fn() -> bool,
+    mut visit: impl FnMut(&[u8]),
+) -> bool {
+    try_for_each_line(path, cancel_every, is_cancelled, |line| {
+        visit(line);
+        Ok::<(), CliError>(())
+    })
+    .unwrap_or(false)
+}
+
+/// Fallible variant of `for_each_line`: `visit` may return `Err`, which
+/// aborts the stream and is propagated. Returns `Ok(true)` if cancelled,
+/// `Ok(false)` if completed, `Err(e)` if `visit` failed.
+pub(crate) fn try_for_each_line(
+    path: &Path,
+    cancel_every: usize,
+    is_cancelled: impl Fn() -> bool,
+    mut visit: impl FnMut(&[u8]) -> Result<()>,
+) -> Result<bool> {
+    let Ok(file) = fs::File::open(path) else {
+        return Ok(false);
+    };
+    let mut reader = BufReader::new(file);
+    let mut buf = Vec::new();
+    let mut count: usize = 0;
+    loop {
+        buf.clear();
+        let n = match reader.read_until(b'\n', &mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => break,
+        };
+        let line = trim_line_ending(&buf);
+        count += 1;
+        if count % cancel_every == 0 && is_cancelled() {
+            return Ok(true);
+        }
+        if n == 0 {
+            break;
+        }
+        visit(line)?;
+    }
+    Ok(false)
 }
 
 thread_local! {


### PR DESCRIPTION
Closes #57

**Problem:** With a 57 GB ~/.codex/sessions history (437 files) the vendored loader read every file whole via fs::read, collected every event, then filtered by the 31-day window. The 15s host deadline abandoned the thread instead of cancelling it, so RSS kept growing past 11 GB and the kernel OOM-killed the app. Same path reachable for Claude, though less likely to hit the limit.

**Fix (three layers):**
- **Streaming:** codex_loader::visit_codex_session_file and claude_loader::read_*_file now use BufReader::read_until instead of fs::read + byte_lines; RSS is one line, not one file.
- **Age/size caps:** lib.rs adds should_skip_file_due_to_age_with_since (skip files with mtime before since - 2d, only when since is Some) and enforce_file_size_limit (keep most-recent files until 1 GB). Codex 31-day query now cuts 57 GB to a few hundred MB; differential fixtures with since=None are untouched.
- **Cancellation:** lib.rs exposes set_*_cancel / is_*_cancelled (AtomicBool per provider). Every hot loop polls every 1-2k lines and returns Err(cancelled). host_api clears before spawn, sets on recv_timeout, worker clears on exit. CcusageQueryGuard already serialises same-provider loads.

**Other changes:**
- Downgrade sysinfo 0.39.6 -> 0.38.4 for rustc 1.93 MSRV
- Make tauri macos-private-api unconditional so cargo test passes on macOS (overlay still provides the config key)

**Testing:**
- cargo test -p ccusage-vendor 42 tests pass
- cargo test --lib 202 tests pass
- cargo test --test ccusage_differential 4 tests pass (previously 3 failed due to filtering)
- bun run test 1959 tests pass
- bun run build passes