### PR TITLE
Feat/grok usage costs

### DIFF
--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -59,6 +59,7 @@ host.fs.exists(path: string): boolean
 host.fs.readText(path: string): string   // Throws on error
 host.fs.writeText(path: string, content: string): void  // Throws on error
 host.fs.listDir(path: string): string[]  // Throws if directory cannot be opened; per-entry errors are silently skipped
+host.fs.scanLines(path: string, needle: string): string[]  // Streams a file; returns lines containing needle (cap 20_000). Throws if the file cannot be opened or needle is empty.
 ```
 
 ### Path Expansion

--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -28,7 +28,7 @@ SuperGrok subscribers use the **same data path** as pay-as-you-go Grok Build use
 A web-only SuperGrok subscription does **not** populate UsagePal by itself. Run `grok login` once so the CLI auth file exists, then enable the Grok plugin. After that:
 
 - **Provider card & overview** show your subscription tier and included-credit usage from the billing API.
-- **Share graph** estimates spend from local CLI logs and/or OpenCode xAI history (Today, Yesterday, Last 30 Days, per-model lines). Usage on grok.com that never goes through the CLI or OpenCode is not included.
+- **Share graph** estimates spend from Grok session turns, CLI logs, and/or OpenCode xAI history (Today, Yesterday, Last 30 Days, per-model lines). Usage on grok.com that never goes through the CLI, sessions, or OpenCode is not included.
 
 X Premium+ subscribers with bundled Grok Build access follow the same flow.
 
@@ -87,9 +87,11 @@ Returns remote CLI settings. UsagePal reads `subscription_tier_display` from thi
 Used fields:
 
 - `used.val` — current billing period usage
-- `monthlyLimit.val` — included credit limit
+- `monthlyLimit.val` — included credit limit. `0` is valid for SuperGrok / X Premium+ accounts that do not have a Grok Build credit pool; UsagePal then omits the Credits used bar and still shows plan plus local spend.
 - `onDemandCap.val` — pay-as-you-go cap; `0` or omitted means disabled (typical for subscription-only accounts)
 - `billingPeriodEnd` — current billing period reset time
+
+Linux uses the same `~/.grok/auth.json` and `~/.grok/logs/unified.jsonl` paths as macOS.
 
 ## Displayed Lines
 
@@ -100,16 +102,17 @@ Used fields:
 
 ## Share Graph
 
-UsagePal estimates local spend for the Share graph from two sources on the **Grok** provider only:
+UsagePal estimates local spend for the Share graph from three sources on the **Grok** provider only:
 
-1. **Grok CLI logs** — `~/.grok/logs/unified.jsonl` (or `$GROK_HOME/logs/unified.jsonl`)
-2. **OpenCode xAI history** — assistant messages in `~/.local/share/opencode/opencode.db` with `providerID = 'xai'` (OpenCode OAuth / xAI usage). Estimated USD when OpenCode stores cost or when tokens can be priced from embedded `GROK_PRICING` rates.
+1. **Grok session turns** — `turn_completed` usage in `~/.grok/sessions/**/updates.jsonl` (includes `grok-4.5-build` / `grok-4.6-build` and survives `unified.jsonl` truncation)
+2. **Grok CLI logs** — `~/.grok/logs/unified.jsonl` (or `$GROK_HOME/logs/unified.jsonl`)
+3. **OpenCode xAI history** — assistant messages in `~/.local/share/opencode/opencode.db` with `providerID = 'xai'` (OpenCode OAuth / xAI usage). Estimated USD when OpenCode stores cost or when tokens can be priced from embedded `GROK_PRICING` rates (including grok-4.6 at $2 input / $0.50 cached / $6 output per 1M tokens, the published below-200k list price).
 
 OpenCode Go (`providerID = 'opencode-go'`) stays on its own provider card and does **not** include xAI rows.
 
 ### Merge rule
 
-When both sources have data for the same UTC day, UsagePal prefers the CLI log for that entire day (CLI inference rows win). OpenCode xAI rows are used only for days with no CLI inference. Days are never summed across sources, so overlapping spend is not double-counted.
+When more than one source has data for the same UTC day, UsagePal uses session turns for that entire day if any exist; otherwise the CLI log; otherwise OpenCode xAI. Days are never summed across sources, so overlapping spend is not double-counted. `grok-4.5-build` is shown as Grok 4.5.
 
 Displayed lines:
 
@@ -132,3 +135,4 @@ If both sources are missing or unreadable, billing lines still render and share-
 | HTTP error | "Grok billing request failed (HTTP {status}). Try again later." |
 | Network error | "Grok billing request failed. Check your connection." |
 | Invalid response | "Grok billing response changed." |
+| Included credit limit is `0` | Not an error. Credits used is omitted; plan and local spend still show. |

--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -1,6 +1,6 @@
 # Grok
 
-Tracks Grok Build credit usage from the local Grok CLI login. This single provider covers **SuperGrok**, **SuperGrok Heavy**, and **X Premium+** subscribers — there is no separate SuperGrok plugin.
+Tracks Grok Build credit usage from the local Grok CLI login. This single provider covers **Free**, **X Premium+**, **SuperGrok**, **SuperGrok Plus**, and **SuperGrok Heavy** subscribers — there is no separate SuperGrok plugin.
 
 > Reverse-engineered, undocumented API. May change without notice.
 
@@ -22,7 +22,7 @@ SuperGrok subscribers use the **same data path** as pay-as-you-go Grok Build use
 |------|------|
 | Auth | `~/.grok/auth.json` (created by `grok login`) |
 | Billing credits | `GET https://cli-chat-proxy.grok.com/v1/billing` |
-| Plan label | `GET https://cli-chat-proxy.grok.com/v1/settings` → `subscription_tier_display` (e.g. `SuperGrok`, `SuperGrok Heavy`) |
+| Plan label | `GET https://cli-chat-proxy.grok.com/v1/settings` → `subscription_tier_display` (e.g. `Free`, `X Premium+`, `SuperGrok`, `SuperGrok Plus`, and `SuperGrok Heavy`) |
 | Share graph / model breakdown | `~/.grok/logs/unified.jsonl` (or `$GROK_HOME/logs/unified.jsonl`), plus OpenCode xAI history from `~/.local/share/opencode/opencode.db` when present |
 
 A web-only SuperGrok subscription does **not** populate UsagePal by itself. Run `grok login` once so the CLI auth file exists, then enable the Grok plugin. After that:
@@ -34,7 +34,7 @@ X Premium+ subscribers with bundled Grok Build access follow the same flow.
 
 ## Setup
 
-1. Install and sign in to the Grok CLI (works for SuperGrok, SuperGrok Heavy, and X Premium+):
+1. Install and sign in to the Grok CLI (works for Free, X Premium+, SuperGrok, SuperGrok Plus, SuperGrok Heavy):
 
 ```bash
 grok login
@@ -87,7 +87,7 @@ Returns remote CLI settings. UsagePal reads `subscription_tier_display` from thi
 Used fields:
 
 - `used.val` — current billing period usage
-- `monthlyLimit.val` — included credit limit. `0` is valid for SuperGrok / X Premium+ accounts that do not have a Grok Build credit pool; UsagePal then omits the Credits used bar and still shows plan plus local spend.
+- `monthlyLimit.val` — included credit limit. `0` is valid for accounts without a Grok Build credit pool (observed on lapsed/`Free` accounts); some tiers may omit `used`/`monthlyLimit` entirely, in which case UsagePal likewise omits the Credits used bar and still shows plan plus local spend. SuperGrok Plus/Heavy pool shapes are handled defensively and await confirmation against live payloads.
 - `onDemandCap.val` — pay-as-you-go cap; `0` or omitted means disabled (typical for subscription-only accounts)
 - `billingPeriodEnd` — current billing period reset time
 

--- a/plugins/grok/plugin.js
+++ b/plugins/grok/plugin.js
@@ -247,6 +247,10 @@
   }
 
   const LOG_RELATIVE = "/logs/unified.jsonl"
+  const SESSIONS_ROOT = "~/.grok/sessions"
+  const COST_USD_TICKS_PER_DOLLAR = 1e10
+  const MAX_SESSION_WALK_DEPTH = 8
+  const MAX_SESSION_UPDATE_FILES = 4000
   const OPENCODE_DB_PATH = "~/.local/share/opencode/opencode.db"
 
   // OpenCode assistant rows with providerID = 'xai' (not 'opencode-go').
@@ -298,6 +302,7 @@
     models: {
       "grok-4.20": { input: 2.0, cache_write: null, cache_read: 0.2, output: 6.0 },
       "grok-4.3": { input: 1.25, cache_write: null, cache_read: 0.2, output: 2.5 },
+      "grok-4.6": { input: 2.0, cache_write: null, cache_read: 0.5, output: 6.0 },
       "grok-4.5": { input: 2.0, cache_write: null, cache_read: 0.2, output: 6.0 },
       "grok-4.5-fast": { input: 4.0, cache_write: null, cache_read: 0.4, output: 18.0 },
       "grok-build-0.1": { input: 1.0, cache_write: null, cache_read: 0.2, output: 2.0 },
@@ -308,6 +313,7 @@
       { pattern: "^grok-composer-2\\.5-fast", canonical: "composer-2.5-fast" },
       { pattern: "^grok-4\\.20", canonical: "grok-4.20" },
       { pattern: "^grok-4\\.3", canonical: "grok-4.3" },
+      { pattern: "^grok-4\\.6", canonical: "grok-4.6" },
       { pattern: "^grok-4\\.5-fast", canonical: "grok-4.5-fast" },
       { pattern: "^grok-4\\.5", canonical: "grok-4.5" },
     ],
@@ -477,64 +483,195 @@
     return Number.isFinite(ms) ? ms : null
   }
 
+  function parseLogLine(line) {
+    if (!line) return null
+    if (line.indexOf("inference_done") === -1 && line.indexOf("model") === -1) return null
+    let object = null
+    try {
+      object = JSON.parse(line)
+    } catch (e) {
+      return null
+    }
+    if (!object || typeof object !== "object") return null
+    const msg = typeof object.msg === "string" ? object.msg : ""
+    const ctxObj = object.ctx && typeof object.ctx === "object" ? object.ctx : {}
+    const pid = readNumber(object.pid)
+    const modelFromEvent = modelIDFromEvent(msg, ctxObj)
+    if (modelFromEvent) {
+      return { kind: "model", pid: pid, model: modelFromEvent }
+    }
+    if (msg !== "shell.turn.inference_done") return null
+    const promptTokens = readNumber(ctxObj.prompt_tokens)
+    if (promptTokens === null) return null
+    const tsMs = parseTimestamp(object.ts)
+    if (tsMs === null) return null
+    const completion = readNumber(ctxObj.completion_tokens) || 0
+    const reasoning = readNumber(ctxObj.reasoning_tokens) || 0
+    const cachedRaw = readNumber(ctxObj.cached_prompt_tokens) || 0
+    const cached = Math.min(cachedRaw, promptTokens)
+    return {
+      kind: "inference",
+      pid: pid,
+      tsMs: tsMs,
+      promptTokens: promptTokens,
+      cacheRead: cached,
+      output: completion + reasoning,
+      totalTokens: promptTokens + completion + reasoning,
+    }
+  }
+
   function buildUsageRowsFromLog(ctx, text, sinceMs) {
-    const modelByPID = {}
-    const rows = []
-
     const lines = String(text || "").split(/\r?\n/)
+    const events = []
+    const firstByPid = {}
+    let firstGlobal = null
     for (let i = 0; i < lines.length; i += 1) {
-      const line = lines[i]
-      if (!line) continue
-      if (line.indexOf("inference_done") === -1 && line.indexOf("model") === -1) continue
+      const event = parseLogLine(lines[i])
+      if (!event) continue
+      events.push(event)
+      if (event.kind !== "model") continue
+      if (!firstGlobal) firstGlobal = event.model
+      if (event.pid !== null && firstByPid[event.pid] === undefined) {
+        firstByPid[event.pid] = event.model
+      }
+    }
 
+    const modelByPID = {}
+    const firstKeys = Object.keys(firstByPid)
+    for (let i = 0; i < firstKeys.length; i += 1) {
+      modelByPID[firstKeys[i]] = firstByPid[firstKeys[i]]
+    }
+    let lastModel = firstGlobal
+    const rows = []
+    for (let i = 0; i < events.length; i += 1) {
+      const event = events[i]
+      if (event.kind === "model") {
+        lastModel = event.model
+        if (event.pid !== null) modelByPID[event.pid] = event.model
+        continue
+      }
+      if (event.tsMs < sinceMs) continue
+      const pidKey = event.pid !== null ? String(event.pid) : ""
+      const model = (pidKey && modelByPID[pidKey]) || lastModel
+      if (!model) continue
+      const inputNoCache = Math.max(0, event.promptTokens - event.cacheRead)
+      const cost = estimatedCostDollars(model, inputNoCache, event.cacheRead, event.output)
+      rows.push({
+        createdMs: event.tsMs,
+        cost: cost !== null ? cost : 0,
+        model: model,
+        tokens: event.totalTokens,
+      })
+    }
+    return rows
+  }
+
+  function timestampToMs(raw) {
+    const n = Number(raw)
+    if (!Number.isFinite(n) || n <= 0) return null
+    return n > 1e12 ? n : n * 1000
+  }
+
+  function sessionTurnCostUsd(usage, model) {
+    const ticks = readNumber(usage && usage.costUsdTicks)
+    if (ticks !== null && ticks > 0) return ticks / COST_USD_TICKS_PER_DOLLAR
+    const input = Math.max(0, readNumber(usage && usage.inputTokens) || 0)
+    const cached = Math.min(Math.max(0, readNumber(usage && usage.cachedReadTokens) || 0), input)
+    const output =
+      Math.max(0, readNumber(usage && usage.outputTokens) || 0) +
+      Math.max(0, readNumber(usage && usage.reasoningTokens) || 0)
+    const estimated = estimatedCostDollars(model, Math.max(0, input - cached), cached, output)
+    return estimated !== null ? estimated : 0
+  }
+
+  function buildUsageRowsFromSessionLines(lines, sinceMs) {
+    const rows = []
+    const list = Array.isArray(lines) ? lines : []
+    for (let i = 0; i < list.length; i += 1) {
       let object = null
       try {
-        object = JSON.parse(line)
+        object = JSON.parse(list[i])
       } catch (e) {
         continue
       }
       if (!object || typeof object !== "object") continue
+      const update =
+        object.params && object.params.update && typeof object.params.update === "object"
+          ? object.params.update
+          : object.update && typeof object.update === "object"
+            ? object.update
+            : object
+      if (update.sessionUpdate !== "turn_completed") continue
+      const createdMs = timestampToMs(object.timestamp)
+      if (createdMs === null || createdMs < sinceMs) continue
+      const usage = update.usage && typeof update.usage === "object" ? update.usage : null
+      const modelUsage = usage && usage.modelUsage && typeof usage.modelUsage === "object"
+        ? usage.modelUsage
+        : null
+      if (!modelUsage) continue
+      const models = Object.keys(modelUsage)
+      for (let m = 0; m < models.length; m += 1) {
+        const model = models[m]
+        const part = modelUsage[model]
+        if (!part || typeof part !== "object") continue
+        const tokens = readNumber(part.totalTokens)
+        const tokenCount =
+          tokens !== null && tokens > 0
+            ? Math.round(tokens)
+            : Math.max(0, readNumber(part.inputTokens) || 0) +
+              Math.max(0, readNumber(part.outputTokens) || 0)
+        if (tokenCount <= 0 && sessionTurnCostUsd(part, model) <= 0) continue
+        rows.push({
+          createdMs: createdMs,
+          cost: sessionTurnCostUsd(part, model),
+          model: model,
+          tokens: tokenCount,
+        })
+      }
+    }
+    return rows
+  }
 
-      const msg = typeof object.msg === "string" ? object.msg : ""
-      const ctxObj = object.ctx && typeof object.ctx === "object" ? object.ctx : {}
-      const pid = readNumber(object.pid)
-
-      const modelFromEvent = modelIDFromEvent(msg, ctxObj)
-      if (modelFromEvent) {
-        if (pid !== null) modelByPID[pid] = modelFromEvent
+  function collectSessionUpdateFiles(ctx, dir, out, depth) {
+    if (depth > MAX_SESSION_WALK_DEPTH || out.length >= MAX_SESSION_UPDATE_FILES) return
+    if (!ctx.host.fs || typeof ctx.host.fs.listDir !== "function") return
+    let names = []
+    try {
+      names = ctx.host.fs.listDir(dir)
+    } catch (e) {
+      return
+    }
+    if (!Array.isArray(names)) return
+    for (let i = 0; i < names.length; i += 1) {
+      const name = names[i]
+      if (!name) continue
+      const path = dir.replace(/\/+$/, "") + "/" + name
+      if (name === "updates.jsonl") {
+        out.push(path)
+        if (out.length >= MAX_SESSION_UPDATE_FILES) return
         continue
       }
-
-      if (msg !== "shell.turn.inference_done") continue
-
-      const promptTokens = readNumber(ctxObj.prompt_tokens)
-      if (promptTokens === null) continue
-
-      const tsMs = parseTimestamp(object.ts)
-      if (tsMs === null || tsMs < sinceMs) continue
-
-      const completion = readNumber(ctxObj.completion_tokens) || 0
-      const reasoning = readNumber(ctxObj.reasoning_tokens) || 0
-      const cachedRaw = readNumber(ctxObj.cached_prompt_tokens) || 0
-      const cached = Math.min(cachedRaw, promptTokens)
-      const cacheRead = cached
-      const inputNoCache = Math.max(0, promptTokens - cached)
-      const output = completion + reasoning
-      const totalTokens = promptTokens + output
-
-      const model = pid !== null ? modelByPID[pid] : null
-      if (!model) continue
-
-      const cost = estimatedCostDollars(model, inputNoCache, cacheRead, output)
-
-      rows.push({
-        createdMs: tsMs,
-        cost: cost !== null ? cost : 0,
-        model: model,
-        tokens: totalTokens,
-      })
+      collectSessionUpdateFiles(ctx, path, out, depth + 1)
+      if (out.length >= MAX_SESSION_UPDATE_FILES) return
     }
+  }
 
+  function loadSessionUsageRows(ctx, sinceMs) {
+    if (!ctx.host.fs || typeof ctx.host.fs.scanLines !== "function") return []
+    const files = []
+    collectSessionUpdateFiles(ctx, SESSIONS_ROOT, files, 0)
+    const rows = []
+    for (let i = 0; i < files.length; i += 1) {
+      let lines = []
+      try {
+        lines = ctx.host.fs.scanLines(files[i], "turn_completed")
+      } catch (e) {
+        ctx.host.log.warn("grok session scan failed: " + String(e))
+        continue
+      }
+      const part = buildUsageRowsFromSessionLines(lines, sinceMs)
+      for (let r = 0; r < part.length; r += 1) rows.push(part[r])
+    }
     return rows
   }
 
@@ -670,8 +807,9 @@
   }
 
   function prettifyGrokModelName(rawId) {
-    const s = String(rawId || "").trim()
+    let s = String(rawId || "").trim()
     if (!s) return s
+    if (/-build$/i.test(s)) s = s.replace(/-build$/i, "")
     return s
       .split("-")
       .map(function (part, index) {
@@ -792,14 +930,17 @@
   }
 
   function appendSpendHistory(ctx, lines, nowMs) {
+    const sinceMs = nowMs - 31 * 24 * 60 * 60 * 1000
     const text = readLogText(ctx)
-    const cliRows = text !== null ? buildUsageRowsFromLog(ctx, text, nowMs - 31 * 24 * 60 * 60 * 1000) : []
+    const cliRows = text !== null ? buildUsageRowsFromLog(ctx, text, sinceMs) : []
+    const sessionRows = loadSessionUsageRows(ctx, sinceMs)
 
     const openCodeResult = loadOpenCodeXaiHistory(ctx)
     const openCodeRows = openCodeResult.ok ? openCodeResult.rows : []
 
-    // Prefer CLI for UTC days that have CLI inference; otherwise OpenCode xAI.
-    const rows = mergeUsageRowsByDay(cliRows, openCodeRows)
+    // Session turn_completed totals win a UTC day (they keep Grok 4.5 after
+    // unified.jsonl truncates). Else CLI inference; else OpenCode xAI.
+    const rows = mergeUsageRowsByDay(sessionRows, mergeUsageRowsByDay(cliRows, openCodeRows))
     if (rows.length === 0) return
 
     const daily = aggregateDailyFromRows(rows, nowMs)
@@ -872,7 +1013,7 @@
     const usedUnits = unitsValue(config.used)
     const limitUnits = unitsValue(config.monthlyLimit)
     const onDemandCapUnits = unitsValue(config.onDemandCap) ?? 0
-    if (usedUnits === null || limitUnits === null || limitUnits <= 0) {
+    if (usedUnits === null || limitUnits === null) {
       throw "Grok billing response changed."
     }
 
@@ -881,21 +1022,25 @@
       throw "Grok billing response changed."
     }
 
-    const usedPercent = clampPercent((usedUnits / limitUnits) * 100)
-    const lines = [
-      ctx.line.progress({
-        label: "Credits used",
-        used: usedPercent,
-        limit: 100,
-        format: { kind: "percent" },
-        resetsAt,
-      }),
+    const lines = []
+    if (limitUnits > 0) {
+      lines.push(
+        ctx.line.progress({
+          label: "Credits used",
+          used: clampPercent((usedUnits / limitUnits) * 100),
+          limit: 100,
+          format: { kind: "percent" },
+          resetsAt,
+        }),
+      )
+    }
+    lines.push(
       ctx.line.badge({
         label: "Pay as you go",
         text: onDemandCapUnits > 0 ? String(onDemandCapUnits) + " cap" : "Disabled",
         color: onDemandCapUnits > 0 ? "#22c55e" : "#a3a3a3",
       }),
-    ]
+    )
 
     appendSpendHistory(ctx, lines, nowMs(ctx))
 
@@ -907,6 +1052,8 @@
     probe,
     __test: {
       logPath,
+      buildUsageRowsFromSessionLines,
+      loadSessionUsageRows,
       resolveModelRates,
       estimatedCostDollars,
       modelIDFromEvent,

--- a/plugins/grok/plugin.js
+++ b/plugins/grok/plugin.js
@@ -1013,17 +1013,13 @@
     const usedUnits = unitsValue(config.used)
     const limitUnits = unitsValue(config.monthlyLimit)
     const onDemandCapUnits = unitsValue(config.onDemandCap) ?? 0
-    if (usedUnits === null || limitUnits === null) {
-      throw "Grok billing response changed."
-    }
-
-    const resetsAt = ctx.util.toIso(config.billingPeriodEnd)
-    if (!resetsAt) {
-      throw "Grok billing response changed."
-    }
+    const hasCreditPool = usedUnits !== null && limitUnits !== null
 
     const lines = []
-    if (limitUnits > 0) {
+    if (hasCreditPool && limitUnits > 0) {
+      const resetsAt = ctx.util.toIso(config.billingPeriodEnd)
+      if (!resetsAt)
+        throw "Grok billing response changed."
       lines.push(
         ctx.line.progress({
           label: "Credits used",
@@ -1034,6 +1030,7 @@
         }),
       )
     }
+
     lines.push(
       ctx.line.badge({
         label: "Pay as you go",

--- a/plugins/grok/plugin.test.js
+++ b/plugins/grok/plugin.test.js
@@ -300,6 +300,71 @@ describe("grok plugin", () => {
     expect(result.lines.find((l) => l.label === "Current period")).toBeUndefined()
     expect(result.lines.find((l) => l.label === "Billing cycle")).toBeUndefined()
   })
+  it("shows Free subscription tier from settings", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, billingData(), {
+      status: 200,
+      bodyText: JSON.stringify({subscription_tier_display: "Free"}),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("Free")
+  })
+
+  it("passes through unrecognized tier strings verbatim", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, billingData(), {
+      status: 200,
+      bodyText: JSON.stringify({subscription_tier_display: "X Premium+"})
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("X Premium+")
+  })
+
+  it("still probes for SuperGrok when pool fields are omitted", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, billingData({
+      monthlyLimit: undefined,
+      used: undefined,
+    }), {
+      status: 200,
+      bodyText: JSON.stringify({subscription_tier_display: "SuperGrok"})
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("SuperGrok")
+    expect(result.lines.find((l) => l.label === "Credits used")).toBeUndefined()
+    expect(result.lines.find((l) => l.label === "Pay as you go")).toBeDefined()
+  })
+
+  it("still probes for SuperGrok Plus when pool fields are omitted", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, billingData({
+      monthlyLimit: undefined,
+      used: undefined,
+    }), {
+      status: 200,
+      bodyText: JSON.stringify({subscription_tier_display: "SuperGrok Plus"})
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("SuperGrok Plus")
+    expect(result.lines.find((l) => l.label === "Credits used")).toBeUndefined()
+    expect(result.lines.find((l) => l.label === "Pay as you go")).toBeDefined()
+  })
 
   it("still probes when included credit limit is zero", async () => {
     const ctx = makeCtx()
@@ -389,6 +454,34 @@ describe("grok plugin", () => {
     const result = plugin.probe(ctx)
 
     expect(result.plan).toBe("SuperGrok")
+  })
+
+  it("shows SuperGrok Plus subscription tier from settings", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, billingData(), {
+      status: 200,
+      bodyText: JSON.stringify({subscription_tier_display: "SuperGrok Plus"}),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("SuperGrok Plus")
+  })
+
+  it("shows SuperGrok Heavy subscription tier from settings", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, billingData(), {
+      status: 200,
+      bodyText: JSON.stringify({subscription_tier_display: "SuperGrok Heavy"}),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("SuperGrok Heavy")
   })
 
   it("treats missing onDemandCap as disabled for subscription-only billing", async () => {

--- a/plugins/grok/plugin.test.js
+++ b/plugins/grok/plugin.test.js
@@ -77,7 +77,7 @@ describe("grok plugin", () => {
 
   it("throws when auth file has no usable token", async () => {
     const ctx = makeCtx()
-    ctx.host.fs.writeText(AUTH_PATH, JSON.stringify({ account: { email: "user@example.com" } }))
+    ctx.host.fs.writeText(AUTH_PATH, JSON.stringify({account: {email: "user@example.com"}}))
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Grok auth invalid. Run `grok login` again.")
   })
@@ -122,10 +122,10 @@ describe("grok plugin", () => {
       if (req.url === SETTINGS_URL) {
         return {
           status: 200,
-          bodyText: JSON.stringify({ subscription_tier_display: "SuperGrok Heavy" }),
+          bodyText: JSON.stringify({subscription_tier_display: "SuperGrok Heavy"}),
         }
       }
-      return { status: 404, bodyText: "" }
+      return {status: 404, bodyText: ""}
     })
 
     const plugin = await loadPlugin()
@@ -158,7 +158,7 @@ describe("grok plugin", () => {
     ctx.host.http.request.mockImplementation((req) => {
       if (req.url === BILLING_URL) {
         billingCalls += 1
-        if (billingCalls === 1) return { status: 401, bodyText: "" }
+        if (billingCalls === 1) return {status: 401, bodyText: ""}
         return {
           status: 200,
           bodyText: JSON.stringify(billingData()),
@@ -177,10 +177,10 @@ describe("grok plugin", () => {
       if (req.url === SETTINGS_URL) {
         return {
           status: 200,
-          bodyText: JSON.stringify({ subscription_tier_display: "SuperGrok Heavy" }),
+          bodyText: JSON.stringify({subscription_tier_display: "SuperGrok Heavy"}),
         }
       }
-      return { status: 404, bodyText: "" }
+      return {status: 404, bodyText: ""}
     })
 
     const plugin = await loadPlugin()
@@ -188,8 +188,8 @@ describe("grok plugin", () => {
 
     expect(result.plan).toBe("SuperGrok Heavy")
     const billingAuths = ctx.host.http.request.mock.calls
-      .filter((call) => call[0].url === BILLING_URL)
-      .map((call) => call[0].headers.Authorization)
+        .filter((call) => call[0].url === BILLING_URL)
+        .map((call) => call[0].headers.Authorization)
     expect(billingAuths).toEqual(["Bearer old-token", "Bearer new-token"])
     const refreshCall = ctx.host.http.request.mock.calls.find((call) => call[0].url === REFRESH_URL)[0]
     expect(refreshCall.bodyText).toContain("client_id=client")
@@ -208,7 +208,7 @@ describe("grok plugin", () => {
       if (req.url === REFRESH_URL) {
         return {
           status: 401,
-          bodyText: JSON.stringify({ error: "invalid_grant" }),
+          bodyText: JSON.stringify({error: "invalid_grant"}),
         }
       }
       if (req.url === BILLING_URL) {
@@ -220,10 +220,10 @@ describe("grok plugin", () => {
       if (req.url === SETTINGS_URL) {
         return {
           status: 200,
-          bodyText: JSON.stringify({ subscription_tier_display: "SuperGrok Heavy" }),
+          bodyText: JSON.stringify({subscription_tier_display: "SuperGrok Heavy"}),
         }
       }
-      return { status: 404, bodyText: "" }
+      return {status: 404, bodyText: ""}
     })
 
     const plugin = await loadPlugin()
@@ -284,7 +284,7 @@ describe("grok plugin", () => {
     expect(line.type).toBe("progress")
     expect(line.used).toBeCloseTo(7.128, 3)
     expect(line.limit).toBe(100)
-    expect(line.format).toEqual({ kind: "percent" })
+    expect(line.format).toEqual({kind: "percent"})
     expect(line.resetsAt).toBe("2026-06-01T00:00:00.000Z")
   })
 
@@ -301,10 +301,26 @@ describe("grok plugin", () => {
     expect(result.lines.find((l) => l.label === "Billing cycle")).toBeUndefined()
   })
 
+  it("still probes when included credit limit is zero", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, billingData({
+      monthlyLimit: {val: 0},
+      used: {val: 0},
+    }))
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("SuperGrok Heavy")
+    expect(result.lines.find((l) => l.label === "Credits used")).toBeUndefined()
+    expect(result.lines.find((l) => l.label === "Pay as you go").text).toBe("Disabled")
+  })
+
   it("renders pay as you go disabled when cap is zero", async () => {
     const ctx = makeCtx()
     writeAuth(ctx)
-    mockGrokApi(ctx, billingData({ onDemandCap: { val: 0 } }))
+    mockGrokApi(ctx, billingData({onDemandCap: {val: 0}}))
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
@@ -318,7 +334,7 @@ describe("grok plugin", () => {
   it("renders pay as you go cap when enabled", async () => {
     const ctx = makeCtx()
     writeAuth(ctx)
-    mockGrokApi(ctx, billingData({ onDemandCap: { val: "2500" } }))
+    mockGrokApi(ctx, billingData({onDemandCap: {val: "2500"}}))
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
@@ -332,9 +348,9 @@ describe("grok plugin", () => {
     const ctx = makeCtx()
     writeAuth(ctx)
     mockGrokApi(ctx, billingData({
-      monthlyLimit: { val: "10000" },
-      used: { val: "2500" },
-      onDemandCap: { val: "0" },
+      monthlyLimit: {val: "10000"},
+      used: {val: "2500"},
+      onDemandCap: {val: "0"},
     }))
 
     const plugin = await loadPlugin()
@@ -349,7 +365,7 @@ describe("grok plugin", () => {
     writeAuth(ctx)
     mockGrokApi(ctx, billingData(), {
       status: 200,
-      bodyText: JSON.stringify({ subscription_tier_display: "SuperGrok Heavy" }),
+      bodyText: JSON.stringify({subscription_tier_display: "SuperGrok Heavy"}),
     })
 
     const plugin = await loadPlugin()
@@ -366,7 +382,7 @@ describe("grok plugin", () => {
     writeAuth(ctx)
     mockGrokApi(ctx, billingData(), {
       status: 200,
-      bodyText: JSON.stringify({ subscription_tier_display: "SuperGrok" }),
+      bodyText: JSON.stringify({subscription_tier_display: "SuperGrok"}),
     })
 
     const plugin = await loadPlugin()
@@ -378,7 +394,7 @@ describe("grok plugin", () => {
   it("treats missing onDemandCap as disabled for subscription-only billing", async () => {
     const ctx = makeCtx()
     writeAuth(ctx)
-    mockGrokApi(ctx, billingData({ onDemandCap: undefined }))
+    mockGrokApi(ctx, billingData({onDemandCap: undefined}))
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
@@ -393,7 +409,7 @@ describe("grok plugin", () => {
     writeAuth(ctx)
     mockGrokApi(ctx, billingData(), {
       status: 200,
-      bodyText: JSON.stringify({ release_channel: "stable" }),
+      bodyText: JSON.stringify({release_channel: "stable"}),
     })
 
     const plugin = await loadPlugin()
@@ -405,7 +421,7 @@ describe("grok plugin", () => {
   it("throws when billing request returns auth error", async () => {
     const ctx = makeCtx()
     writeAuth(ctx)
-    ctx.host.http.request.mockReturnValue({ status: 401, bodyText: "" })
+    ctx.host.http.request.mockReturnValue({status: 401, bodyText: ""})
 
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Grok auth expired. Run `grok login` again.")
@@ -414,7 +430,7 @@ describe("grok plugin", () => {
   it("throws on billing HTTP error", async () => {
     const ctx = makeCtx()
     writeAuth(ctx)
-    ctx.host.http.request.mockReturnValue({ status: 500, bodyText: "" })
+    ctx.host.http.request.mockReturnValue({status: 500, bodyText: ""})
 
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Grok billing request failed (HTTP 500). Try again later.")
@@ -434,16 +450,27 @@ describe("grok plugin", () => {
   it("throws on invalid billing JSON", async () => {
     const ctx = makeCtx()
     writeAuth(ctx)
-    ctx.host.http.request.mockReturnValue({ status: 200, bodyText: "not-json" })
+    ctx.host.http.request.mockReturnValue({status: 200, bodyText: "not-json"})
 
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Grok billing response changed.")
   })
+  it("omits Credits used when pool fields are absent instead of throwing",
+      async () => {
+        const ctx = makeCtx()
+        writeAuth(ctx)
+        mockGrokApi(ctx, {config: {used: {val: 1 } } })
 
-  it("throws on unexpected billing response shape", async () => {
+        const plugin = await loadPlugin()
+        const result = plugin.probe(ctx)
+
+        expect(result.lines.find((l) => l.label === "Credits used")).toBeUndefined()
+        expect(result.lines.find((l) => l.label === "Pay as you go")).toBeDefined()
+      })
+  it("throws when billing config is missing entirely", async () => {
     const ctx = makeCtx()
     writeAuth(ctx)
-    mockGrokApi(ctx, { config: { used: { val: 1 } } })
+    mockGrokApi(ctx, {})
 
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Grok billing response changed.")
@@ -480,6 +507,138 @@ describe("grok spend aggregation", () => {
     expect(plugin.__test.resolveModelRates("grok-build")).toEqual(
       plugin.__test.GROK_PRICING.models["grok-build-0.1"],
     )
+  })
+
+  it("resolves grok-4.5-build onto grok-4.5 rates", async () => {
+    const plugin = await loadPlugin()
+    expect(plugin.__test.resolveModelRates("grok-4.5-build")).toEqual(
+      plugin.__test.GROK_PRICING.models["grok-4.5"],
+    )
+    expect(plugin.__test.resolveModelRates("grok-4.6-build")).toEqual(
+      plugin.__test.GROK_PRICING.models["grok-4.6"],
+    )
+    expect(plugin.__test.prettifyGrokModelName("grok-4.5-build")).toBe("Grok 4.5")
+    expect(plugin.__test.prettifyGrokModelName("grok-4.6-build")).toBe("Grok 4.6")
+  })
+
+  it("resolves grok-4.6 to published xAI text rates", async () => {
+    const plugin = await loadPlugin()
+    expect(plugin.__test.resolveModelRates("grok-4.6")).toEqual({
+      input: 2.0,
+      cache_write: null,
+      cache_read: 0.5,
+      output: 6.0,
+    })
+    expect(plugin.__test.resolveModelRates("grok-4.6-beta")).toEqual(
+      plugin.__test.GROK_PRICING.models["grok-4.6"],
+    )
+    expect(plugin.__test.estimatedCostDollars("grok-4.6", 1_000_000, 0, 100_000)).toBeCloseTo(2.6)
+  })
+
+  it("attributes inference_done rows that occur before the first model event", async () => {
+    const plugin = await loadPlugin()
+    const text = [
+      inferenceLine("2026-07-01T01:00:00.000Z", 7, { prompt: 1_000_000, completion: 100_000 }),
+      modelLine(7, "grok-4.5"),
+      inferenceLine("2026-07-01T02:00:00.000Z", 7, { prompt: 1_000_000, completion: 100_000 }),
+    ].join("\n")
+    const rows = plugin.__test.buildUsageRowsFromLog(
+      makeCtx(),
+      text,
+      Date.parse("2026-06-01T00:00:00.000Z"),
+    )
+    expect(rows).toHaveLength(2)
+    expect(rows.every((row) => row.model === "grok-4.5")).toBe(true)
+    expect(rows[0].cost).toBeGreaterThan(0)
+  })
+
+  it("reads grok-4.5-build spend from session turn_completed updates", async () => {
+    const plugin = await loadPlugin()
+    const line = JSON.stringify({
+      timestamp: Date.parse("2026-07-01T12:00:00.000Z") / 1000,
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "turn_completed",
+          usage: {
+            modelUsage: {
+              "grok-4.5-build": {
+                inputTokens: 1_000_000,
+                outputTokens: 100_000,
+                cachedReadTokens: 0,
+                reasoningTokens: 0,
+                totalTokens: 1_100_000,
+                costUsdTicks: 26_000_000_000,
+              },
+            },
+          },
+        },
+      },
+    })
+    const rows = plugin.__test.buildUsageRowsFromSessionLines([line], Date.parse("2026-06-01T00:00:00.000Z"))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].model).toBe("grok-4.5-build")
+    expect(rows[0].tokens).toBe(1_100_000)
+    expect(rows[0].cost).toBeCloseTo(2.6)
+  })
+
+  it("prefers session turn totals over truncated CLI logs so Grok 4.5 remains in Last 30 Days", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-07-15T12:00:00.000Z"))
+    try {
+      const plugin = await loadPlugin()
+      const ctx = makeCtx()
+      const sessionLine = JSON.stringify({
+        timestamp: Date.parse("2026-07-01T12:00:00.000Z") / 1000,
+        method: "session/update",
+        params: {
+          update: {
+            sessionUpdate: "turn_completed",
+            usage: {
+              modelUsage: {
+                "grok-4.5-build": {
+                  inputTokens: 2_000_000,
+                  outputTokens: 200_000,
+                  cachedReadTokens: 0,
+                  reasoningTokens: 0,
+                  totalTokens: 2_200_000,
+                  costUsdTicks: 52_000_000_000,
+                },
+              },
+            },
+          },
+        },
+      })
+      ctx.host.fs.writeText("~/.grok/sessions/proj/sess/updates.jsonl", sessionLine + "\nignored\n")
+      ctx.host.fs.writeText(
+        "~/.grok/logs/unified.jsonl",
+        [
+          modelLine(1, "grok-4.6"),
+          inferenceLine("2026-07-15T01:00:00.000Z", 1, { prompt: 10_000, completion: 1_000 }),
+        ].join("\n"),
+      )
+      const lines = []
+      plugin.__test.appendSpendHistory(ctx, lines, Date.now())
+      const byLabel = Object.fromEntries(lines.map((l) => [l.label, l]))
+      expect(byLabel["Last 30 Days"].value).toMatch(/\$/)
+      expect(byLabel["Grok 4.5"]).toBeDefined()
+      expect(byLabel["Grok 4.6"]).toBeDefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("prices grok-4.6 log rows instead of zeroing them", async () => {
+    const plugin = await loadPlugin()
+    const text = [
+      modelLine(7, "grok-4.6"),
+      inferenceLine("2026-07-01T01:00:00.000Z", 7, { prompt: 1_000_000, completion: 100_000 }),
+    ].join("\n")
+    const ctx = makeCtx()
+    const rows = plugin.__test.buildUsageRowsFromLog(ctx, text, Date.parse("2026-06-01T00:00:00.000Z"))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].model).toBe("grok-4.6")
+    expect(rows[0].cost).toBeCloseTo(2.6)
   })
 
   it("keeps token rows for unknown models with zero cost", async () => {

--- a/plugins/test-helpers.js
+++ b/plugins/test-helpers.js
@@ -39,6 +39,16 @@ export const makeCtx = () => {
           }
           return Array.from(out).sort()
         },
+        scanLines: (path, needle) => {
+          const text = files.get(path)
+          if (typeof text !== "string" || !needle) return []
+          const out = []
+          const parts = text.split(/\r?\n/)
+          for (let i = 0; i < parts.length; i += 1) {
+            if (parts[i].indexOf(needle) !== -1) out.push(parts[i])
+          }
+          return out
+        },
       },
       env: {
         get: vi.fn(() => null),

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -842,6 +842,18 @@ fn inject_fs<'js>(ctx: &Ctx<'js>, host: &Object<'js>) -> rquickjs::Result<()> {
         )?,
     )?;
 
+    fs_obj.set(
+        "scanLines",
+        Function::new(
+            ctx.clone(),
+            move |ctx_inner: Ctx<'_>, path: String, needle: String| -> rquickjs::Result<Vec<String>> {
+                let expanded = expand_path(&path);
+                scan_lines_containing(&expanded, &needle, SCAN_LINES_MAX_MATCHES)
+                    .map_err(|e| Exception::throw_message(&ctx_inner, &e))
+            },
+        )?,
+    )?;
+
     host.set("fs", fs_obj)?;
     Ok(())
 }
@@ -2576,6 +2588,31 @@ fn iso_now() -> String {
         })
 }
 
+const SCAN_LINES_MAX_MATCHES: usize = 20_000;
+
+fn scan_lines_containing(
+    path: &str,
+    needle: &str,
+    max_matches: usize,
+) -> Result<Vec<String>, String> {
+    if needle.is_empty() {
+        return Err("scanLines needle must not be empty".to_string());
+    }
+    let file = std::fs::File::open(path).map_err(|e| e.to_string())?;
+    let reader = std::io::BufReader::new(file);
+    let mut out = Vec::new();
+    for line in std::io::BufRead::lines(reader) {
+        let line = line.map_err(|e| e.to_string())?;
+        if line.contains(needle) {
+            out.push(line);
+            if out.len() >= max_matches {
+                break;
+            }
+        }
+    }
+    Ok(out)
+}
+
 fn expand_path(path: &str) -> String {
     if path == "~" {
         if let Some(home) = dirs::home_dir() {
@@ -3174,6 +3211,23 @@ mod tests {
         let expected = home.join(".claude-custom").to_string_lossy().to_string();
 
         assert_eq!(expand_path("~/.claude-custom"), expected);
+    }
+
+    #[test]
+    fn scan_lines_containing_returns_matching_lines_only() {
+        let dir = std::env::temp_dir().join(format!("usagepal-scan-lines-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("updates.jsonl");
+        std::fs::write(
+            &path,
+            "noise\n{\"sessionUpdate\":\"turn_completed\"}\nstill noise\n{\"sessionUpdate\":\"turn_completed\",\"n\":2}\n",
+        )
+        .expect("write");
+        let matches = scan_lines_containing(path.to_str().expect("utf8"), "turn_completed", 20)
+            .expect("scan");
+        assert_eq!(matches.len(), 2);
+        assert!(matches[0].contains("turn_completed"));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## Description

1. **Sessions-turns spend source** - Share graph now also reads `turn_completed` usage from `~/.grok/sessions/**/updates.jsonl` , which survives `unified.jsonl` truncation.  Priority per UTC day: sessions turns, then CLI log.  Includes per-PID model attribution in log parsing, grok-4.6 pricing, and a new `host.fs.scanLines` API (Rust + mock + docs) backing the session walk.

2. **Pool-less tier tolerance** - billing configs without `used` / `monthlyLimit` (subscription-only tiers) no longer fail the whole probe.  The credits bar is omitted, while the plan label and pay-as-you-go badge are shown, and spend history keeps rendering.  A missing `config` object, or a pool with no billing period, still throws.  Tier display tests for Free, SuperGrok, SuperGrok Plus, SuperGrok Heavy, and X Premium+.  My SuperGrok Heavy subscription ended last week, so live payloads await confirmation - verified against my `Free` account.

## Related Issue

None — no linked issue. Happy to file one if maintainers prefer.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] New provider plugin
- [x] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x]  I ran `bunx vitest run` — 1972/1973 passed. The single failure (`plugins/opencode-go local-spend test`) is pre-existing on `main`: a date-sensitive test with no timers (fixed August seed data vs. current date), untouched by this PR.
- [x] I tested the change locally with `bun tauri dev`  — Grok card renders plan `Free` with no Credits bar, spend history intact.

## Screenshots


<img width="1760" height="2268" alt="image" src="https://github.com/user-attachments/assets/efb9c78e-6fbe-4b2f-a01a-12852db3f869" />

<img width="1760" height="1036" alt="image" src="https://github.com/user-attachments/assets/60db5d7b-4beb-4f62-b00b-0217ca0965c6" />

<img width="1760" height="1036" alt="image" src="https://github.com/user-attachments/assets/23539ffe-7cd5-40fa-aa3a-0ba7d627bee5" />

<img width="600" height="630" alt="image" src="https://github.com/user-attachments/assets/6f2415b2-1b7f-4229-9cb9-6ba37350e2ef" />


## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification
